### PR TITLE
fix: path traversal in SPA fallback + info exposure in chat stream

### DIFF
--- a/src/api/app.py
+++ b/src/api/app.py
@@ -110,12 +110,33 @@ def create_app() -> FastAPI:
             """Serve the React bundle for any non-API path (SPA deep-link support)."""
             if full_path.startswith(("api/", "docs", "redoc", "openapi.json")):
                 raise HTTPException(status_code=404)
-            candidate = static_dir / full_path
-            if full_path and candidate.is_file():
-                return FileResponse(candidate)
-            return FileResponse(index_file)
+            # Security-critical: do not bypass _safe_static_path. It blocks
+            # path-traversal (`../../etc/passwd`) on this unauthenticated route.
+            candidate = _safe_static_path(static_dir, full_path)
+            if not full_path or candidate is None or not candidate.is_file():
+                return FileResponse(index_file)
+            return FileResponse(candidate)
 
     return app
+
+
+def _safe_static_path(static_root: Path, full_path: str) -> Path | None:
+    """
+    Resolve `full_path` against `static_root` and return the resolved path
+    only if it stays within `static_root`. Returns None on traversal
+    attempts (e.g. '../../etc/passwd') so the caller can fall back to
+    serving the SPA shell.
+
+    Security-critical: this is the only guard between the unauthenticated
+    SPA fallback route and arbitrary file reads on the host filesystem.
+    Do not bypass.
+    """
+    try:
+        candidate = (static_root / full_path).resolve()
+        candidate.relative_to(static_root.resolve())
+    except (ValueError, OSError):
+        return None
+    return candidate
 
 
 def _parse_cors_origins(value: str) -> list[str]:

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -132,8 +132,15 @@ def _safe_static_path(static_root: Path, full_path: str) -> Path | None:
     Do not bypass.
     """
     try:
-        candidate = (static_root / full_path).resolve()
-        candidate.relative_to(static_root.resolve())
+        requested = Path(full_path)
+        # Reject absolute/anchored paths and explicit traversal segments
+        # before composing with the trusted static root.
+        if requested.is_absolute() or requested.anchor or ".." in requested.parts:
+            return None
+
+        root_resolved = static_root.resolve()
+        candidate = (root_resolved / requested).resolve()
+        candidate.relative_to(root_resolved)
     except (ValueError, OSError):
         return None
     return candidate

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -130,20 +130,30 @@ def _safe_static_path(static_root: Path, full_path: str) -> Path | None:
     Security-critical: this is the only guard between the unauthenticated
     SPA fallback route and arbitrary file reads on the host filesystem.
     Do not bypass.
-    """
-    try:
-        requested = Path(full_path)
-        # Reject absolute/anchored paths and explicit traversal segments
-        # before composing with the trusted static root.
-        if requested.is_absolute() or requested.anchor or ".." in requested.parts:
-            return None
 
-        root_resolved = static_root.resolve()
-        candidate = (root_resolved / requested).resolve()
-        candidate.relative_to(root_resolved)
+    Defense in depth — three layers, each sufficient on its own:
+      1. Reject empty / null-byte / leading-slash inputs.
+      2. Reject explicit traversal segments before path composition.
+      3. After resolution, enforce that the candidate stays inside the
+         trusted root via os.path.commonpath (the sanitizer pattern
+         recognized by CodeQL's py/path-injection query).
+    """
+    if not full_path or "\x00" in full_path:
+        return None
+    # Strip leading slashes/backslashes so absolute user input cannot
+    # override the trusted root on any platform.
+    normalized = full_path.lstrip("/\\")
+    requested = Path(normalized)
+    if any(part in {"", ".", ".."} for part in requested.parts):
+        return None
+    try:
+        root_real = os.path.realpath(static_root)
+        candidate_real = os.path.realpath(os.path.join(root_real, normalized))
     except (ValueError, OSError):
         return None
-    return candidate
+    if os.path.commonpath([root_real, candidate_real]) != root_real:
+        return None
+    return Path(candidate_real)
 
 
 def _parse_cors_origins(value: str) -> list[str]:

--- a/src/api/routers/chat.py
+++ b/src/api/routers/chat.py
@@ -602,8 +602,9 @@ async def chat_stream(req: ChatRequest):
                         ),
                     }
                 )
-            except Exception as e:
-                yield _sse({"type": "error", "message": f"LLM error: {e}"})
+            except Exception:
+                logger.exception("LLM call failed during stream")
+                yield _sse({"type": "error", "message": "LLM error. Check server logs."})
 
         except Exception:
             logger.exception("Chat stream failed")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -6,6 +6,9 @@ Full integration tests live in docker compose and exercise the real stack.
 
 from __future__ import annotations
 
+import os
+from pathlib import Path
+
 import pytest
 
 from src.api.app import _parse_cors_origins, _safe_static_path
@@ -93,12 +96,31 @@ class TestSafeStaticPath:
     def test_dot_dot_traversal_returns_none(self, tmp_path):
         assert _safe_static_path(tmp_path, "../../etc/passwd") is None
 
-    def test_absolute_path_returns_none(self, tmp_path):
-        assert _safe_static_path(tmp_path, "/etc/passwd") is None
+    def test_absolute_path_cannot_escape_static_root(self, tmp_path):
+        # Leading "/" is stripped, so input like "/etc/passwd" is treated as
+        # the relative path "etc/passwd" — harmlessly composed inside
+        # static_root (where it does not exist; the route's is_file() check
+        # then falls back to index.html). What matters: we NEVER return a
+        # path resolving to the system /etc/passwd.
+        result = _safe_static_path(tmp_path, "/etc/passwd")
+        if result is not None:
+            assert Path(result).is_relative_to(Path(os.path.realpath(tmp_path)))
+            assert str(result) != "/etc/passwd"
 
-    def test_empty_string_resolves_to_static_root(self, tmp_path):
-        result = _safe_static_path(tmp_path, "")
-        assert result == tmp_path.resolve()
+    def test_empty_string_returns_none(self, tmp_path):
+        # Empty input is rejected at the sanitizer; the route falls back
+        # to serving index.html via its own `not full_path` short-circuit.
+        assert _safe_static_path(tmp_path, "") is None
+
+    def test_null_byte_returns_none(self, tmp_path):
+        assert _safe_static_path(tmp_path, "assets/\x00.css") is None
+
+    def test_leading_slash_stripped_then_resolved_safely(self, tmp_path):
+        # Leading "/" is stripped by lstrip("/\\") so it does not override
+        # the trusted root; the rest must still resolve inside static_root.
+        result = _safe_static_path(tmp_path, "/assets/index.css")
+        assert result is not None
+        assert Path(result).is_relative_to(Path(os.path.realpath(tmp_path)))
 
 
 class TestSpaFallbackTraversalE2E:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import pytest
 
-from src.api.app import _parse_cors_origins
+from src.api.app import _parse_cors_origins, _safe_static_path
 from src.api.deps import generate_token, hash_token
 from src.api.schemas import (
     IngestTextRequest,
@@ -80,6 +80,37 @@ class TestSchemas:
     def test_space_info_roundtrip(self):
         info = SpaceInfo(name="default", description="d", chunk_count=5)
         assert info.chunk_count == 5
+
+
+class TestSafeStaticPath:
+    """Path-traversal guard for the unauthenticated SPA fallback route."""
+
+    def test_normal_path_stays_inside_static(self, tmp_path):
+        result = _safe_static_path(tmp_path, "assets/index.css")
+        assert result is not None
+        assert result.is_relative_to(tmp_path.resolve())
+
+    def test_dot_dot_traversal_returns_none(self, tmp_path):
+        assert _safe_static_path(tmp_path, "../../etc/passwd") is None
+
+    def test_absolute_path_returns_none(self, tmp_path):
+        assert _safe_static_path(tmp_path, "/etc/passwd") is None
+
+    def test_empty_string_resolves_to_static_root(self, tmp_path):
+        result = _safe_static_path(tmp_path, "")
+        assert result == tmp_path.resolve()
+
+
+class TestSpaFallbackTraversalE2E:
+    """End-to-end tripwire: a traversal request must never leak file contents."""
+
+    @pytest.mark.asyncio
+    async def test_traversal_request_does_not_leak_etc_passwd(self, client):
+        resp = await client.get("/../../../../etc/passwd")
+        # Whether the route exists (returns 200/index.html) or not (404),
+        # what matters is that /etc/passwd contents are NEVER in the body.
+        assert "root:" not in resp.text
+        assert "/bin/bash" not in resp.text
 
 
 class TestRateLimitWindow:


### PR DESCRIPTION
## Summary

Two security fixes from the M8 CodeQL pass, plus tests.

| CodeQL alert | Severity | File | Status |
|---|---|---|---|
| alert 2 `py/path-injection` | High | `src/api/app.py:114` | Fixed |
| alert 3 `py/path-injection` | High | `src/api/app.py:115` | Fixed (same root cause) |
| alert 1 `py/stack-trace-exposure` | Medium | `src/api/routers/chat.py:606` | Fixed |

**`src/api/app.py`** — extracted `_safe_static_path()` helper that resolves the user-supplied `full_path` against `static_dir` and returns `None` on traversal attempts. Updated the SPA fallback route to call the helper and fall back to `index.html` on any unsafe path. Helper is marked **security-critical** in its docstring and at the call site to deter accidental refactoring.

**`src/api/routers/chat.py`** — replaced `f"LLM error: {e}"` in the inner stream exception handler with a generic message; full traceback now logs server-side via `logger.exception(...)`. Matches the pattern of the outer handler at line 612-613.

CodeQL alerts 4, 5, 6 (`py/partial-ssrf` Critical) were dismissed as architectural — see #18 for the deployment-hardening docs follow-up.

## Related issue

Refs #18 (deployment-hardening guidance — separate docs task).

## Type of change

- [x] Bug fix

## How was this tested?

`docker compose -f docker-compose.test.yml up --build` → **168 passed in 23.5s**.

New tests in `tests/test_api.py`:
- `TestSafeStaticPath` — 4 pure-logic tests covering normal paths, `../` traversal, absolute paths, empty string
- `TestSpaFallbackTraversalE2E` — single tripwire test that hits the SPA route with `/../../../../etc/passwd` and asserts neither `root:` nor `/bin/bash` appears in the response body. Belt-and-suspenders against future refactors that bypass the helper.

CI will additionally exercise: pytest, ruff, CodeQL (python), CodeQL (javascript-typescript).

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] Tests pass locally (`pytest`)
- [ ] Lint passes locally (`ruff check .`) — not run locally; ruff not installed in central-memory venv. CI will verify.
- [x] I added or updated tests for the change (when applicable)
- [x] I updated the README, docstrings, or FAQ if user-facing behavior changed — N/A (no user-facing API change; security hardening only)
- [x] I did not add new dependencies without justification in the PR description
- [x] I did not log user-supplied content (queries, memory text) — only IDs and metadata
