### PR TITLE
fix: add comments to empty except blocks (CodeQL)

### DIFF
--- a/src/adapters/base.py
+++ b/src/adapters/base.py
@@ -128,6 +128,7 @@ def detect_adapter(file_path: str, content: str = "") -> SourceAdapter:
                 if test and "chat_messages" in test[0]:
                     return ClaudeJsonAdapter()
             except (json.JSONDecodeError, KeyError, IndexError):
+                # Not Claude JSON — fall through to PlainTextAdapter.
                 pass
         return PlainTextAdapter()
 

--- a/src/api/routers/chat.py
+++ b/src/api/routers/chat.py
@@ -217,6 +217,7 @@ async def _detect_model(
                 if models:
                     return models[0].get("id", "default")
     except Exception:
+        # Network/parse failure when probing /v1/models — fall back to "default".
         pass
     return "default"
 

--- a/src/diagnose.py
+++ b/src/diagnose.py
@@ -105,6 +105,7 @@ def _read_version() -> str:
                 # version = "0.4.0"
                 return line.split("=", 1)[1].strip().strip('"').strip("'")
     except OSError:
+        # pyproject.toml unreadable — return "unknown" rather than crash diagnostics.
         pass
     return "unknown"
 

--- a/tests/test_chat_api.py
+++ b/tests/test_chat_api.py
@@ -239,5 +239,6 @@ def _parse_sse(body: str) -> list[dict]:
                     try:
                         events.append(json.loads(payload))
                     except json.JSONDecodeError:
+                        # Skip malformed SSE payloads (e.g. partial frames).
                         pass
     return events


### PR DESCRIPTION
Address CodeQL "Empty except" findings by documenting the intentional fallback behavior in each swallow site:

- chat.py: /v1/models probe failure -> "default" model
- adapters/base.py: not Claude JSON -> PlainTextAdapter
- diagnose.py: pyproject.toml unreadable -> "unknown" version
- test_chat_api.py: malformed SSE payloads skipped

## Summary

Adds explanatory comments to 4 empty `except` blocks flagged by CodeQL. Comments only — no behavior changes. Documents the intentional fallback in each swallow site so future readers (and CodeQL) can see the swallow is deliberate.

## Related issue

N/A — Code Quality scan findings from the GitHub Security tab.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [x] Refactor / internal cleanup
- [ ] Performance improvement
- [ ] Other (describe below)

## How was this tested?

- Comments-only change — no runtime behavior modified
- Existing test suite covers all 4 affected code paths:
  - `tests/test_chat_api.py` — exercises `_parse_sse` and `_detect_model`
  - `tests/test_adapters.py` — exercises `detect_adapter`
  - `tests/test_diagnose_redaction.py` — exercises `diagnose.py`
- CI will re-run `pytest` and `ruff check .` on push
- CodeQL re-scan expected to show 0 "Empty except" findings after merge

## Checklist

- [x] I have read [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md)
- [x] Tests pass locally (`pytest`) — no code paths changed, comments only
- [x] Lint passes locally (`ruff check .`) — comments don't affect lint
- [ ] I added or updated tests for the change (when applicable) — N/A, comments only
- [ ] I updated the README, docstrings, or FAQ if user-facing behavior changed — N/A, no user-facing changes
- [x] I did not add new dependencies without justification in the PR description
- [x] I did not log user-supplied content (queries, memory text) — only IDs and metadata

## Screenshots (UI changes only)

N/A
