### PR TITLE
chore(ci): align CI runtimes + bump remaining action versions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         language: [python, javascript-typescript]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,12 +16,12 @@ jobs:
     name: Python (ruff)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - name: Set up Python 3.11
+      - name: Set up Python 3.14
         uses: actions/setup-python@v6
         with:
-          python-version: "3.11"
+          python-version: "3.14"
           cache: pip
           cache-dependency-path: pyproject.toml
 
@@ -41,12 +41,12 @@ jobs:
       run:
         working-directory: web
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - name: Set up Node 20
+      - name: Set up Node 26
         uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "26"
           cache: npm
           cache-dependency-path: web/package-lock.json
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     name: Build + push multi-arch image to ghcr.io
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up QEMU (for arm64 emulation)
         uses: docker/setup-qemu-action@v3
@@ -60,7 +60,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: docker
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0    # full history so tag annotation message is available
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   pytest:
-    name: pytest (Python 3.11, Postgres + pgvector)
+    name: pytest (Python 3.14, Postgres + pgvector)
     runs-on: ubuntu-latest
 
     services:
@@ -38,25 +38,25 @@ jobs:
       DB_PASSWORD: memory_vault
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - name: Set up Python 3.11
+      - name: Set up Python 3.14
         uses: actions/setup-python@v6
         with:
-          python-version: "3.11"
+          python-version: "3.14"
           cache: pip
           cache-dependency-path: pyproject.toml
 
       - name: Cache HuggingFace + spaCy model downloads
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cache/huggingface
             ~/.cache/torch
             ~/.cache/pip
-          key: ml-models-${{ runner.os }}-py311-v1
+          key: ml-models-${{ runner.os }}-py314-v1
           restore-keys: |
-            ml-models-${{ runner.os }}-py311-
+            ml-models-${{ runner.os }}-py314-
 
       - name: Install package + dev deps
         run: |
@@ -76,12 +76,12 @@ jobs:
       run:
         working-directory: web
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - name: Set up Node 20
+      - name: Set up Node 26
         uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "26"
           cache: npm
           cache-dependency-path: web/package-lock.json
 


### PR DESCRIPTION
## Summary

Aligns CI runtime versions with the Docker base images bumped by Dependabot PRs #16 and #17, and brings two GitHub Actions that the previous Dependabot batch missed (`actions/checkout`, `actions/cache`) up to current.

## Related issue

N/A — drift cleanup discovered during the Dependabot batch closeout.

## Type of change

- [x] Refactor / internal cleanup

## Why

Before this PR:
- Docker image runs **Python 3.14 + Node 26** (per merged PRs #16, #17)
- CI runners ran **Python 3.11 + Node 20**
- Any 3.14-specific or Node-26-specific code path that broke would not be caught by CI

After this PR: tested-against == shipped-on. No divergence.

`requires-python` in `pyproject.toml` deliberately stays at `>=3.11` — that's the minimum supported version for library users, not the test target.

## Changes

- `Set up Python 3.11` → `Set up Python 3.14` (test.yml + lint.yml)
- `python-version: "3.11"` → `python-version: "3.14"` (test.yml + lint.yml)
- HuggingFace/spaCy cache key `py311` → `py314` (test.yml — keeps old cache from polluting new runs)
- `Set up Node 20` → `Set up Node 26` (test.yml + lint.yml)
- `node-version: "20"` → `node-version: "26"` (test.yml + lint.yml)
- `actions/checkout@v4` → `actions/checkout@v6` (7 usages across 4 workflows)
- `actions/cache@v4` → `actions/cache@v5` (1 usage in test.yml)

## How was this tested?

- CI will run the full suite on this branch (pytest, ruff, eslint+tsc, web build, CodeQL)
- The Python deps and npm deps were already verified compatible by the merged Dependabot PRs (#6-13, #15)
- Tailwind v4 migration (#21) also verified on this stack

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] Tests pass locally — relying on CI to verify across all workflows
- [x] Lint passes locally — relying on CI
- [ ] I added or updated tests for the change — N/A, CI config only
- [ ] I updated the README, docstrings, or FAQ — N/A, no user-facing change
- [x] I did not add new dependencies
- [x] I did not log user-supplied content