### PR TITLE
feat(mcp): add Dockerfile.mcp + release matrix for memory-vault-mcp image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,16 @@ permissions:
 
 jobs:
   docker:
-    name: Build + push multi-arch image to ghcr.io
+    name: Build + push ${{ matrix.image }} (multi-arch) to ghcr.io
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image: memory-vault
+            dockerfile: Dockerfile
+          - image: memory-vault-mcp
+            dockerfile: Dockerfile.mcp
     steps:
       - uses: actions/checkout@v6
 
@@ -35,7 +43,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v6
         with:
-          images: ghcr.io/mihaibuilds/memory-vault
+          images: ghcr.io/mihaibuilds/${{ matrix.image }}
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
@@ -48,12 +56,13 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
+          file: ${{ matrix.dockerfile }}
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=${{ matrix.image }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.image }}
 
   release:
     name: Create GitHub Release

--- a/Dockerfile.mcp
+++ b/Dockerfile.mcp
@@ -1,0 +1,30 @@
+# Memory Vault — MCP-only image
+#
+# A thin variant of the main Memory Vault image that ships ONLY the MCP stdio
+# server. No FastAPI, no web dashboard, no API stack. The MCP server connects
+# to an external Postgres+pgvector via env vars (DB_HOST, DB_PORT, DB_NAME,
+# DB_USER, DB_PASSWORD).
+#
+# Intended for: Docker MCP Toolkit catalog + official MCP registry submissions.
+# Users bring their own Postgres (or run the standard docker-compose.yml).
+#
+# Built and pushed by .github/workflows/release.yml on every v*.*.* tag.
+
+FROM python:3.14-slim
+
+WORKDIR /app
+
+# CPU-only PyTorch (sentence-transformers needs torch for embeddings)
+RUN pip install --no-cache-dir torch --index-url https://download.pytorch.org/whl/cpu
+
+COPY pyproject.toml ./
+COPY src/ ./src/
+COPY migrations/ ./migrations/
+
+ENV PYTHONPATH=/app
+
+RUN pip install --no-cache-dir . \
+    && python -m spacy download en_core_web_sm
+
+# stdio MCP server — no port exposed, no healthcheck (stdio has no HTTP surface)
+ENTRYPOINT ["python", "-m", "src.mcp"]


### PR DESCRIPTION
Adds a thin MCP-only Docker image alongside the existing all-in-one image. Required for upcoming MCP registry submissions (both the official MCP registry and Docker MCP Toolkit catalog assume single-image servers with external DB via env vars).

## Summary

Builds and pushes a second image `ghcr.io/mihaibuilds/memory-vault-mcp` on every release tag, alongside the existing `ghcr.io/mihaibuilds/memory-vault`. Same version tags, lockstep.

## Related issue

N/A — distribution prep ahead of MCP registry submissions.

## Type of change

- [x] New feature

## Changes

- **Dockerfile.mcp:** new file. Thin image — Python 3.14-slim + torch (CPU) + Memory Vault package + spaCy. No FastAPI, no React build, no web stack. Entrypoint: `python -m src.mcp` (stdio). Connects to external Postgres via the existing `DB_HOST` / `DB_PORT` / `DB_NAME` / `DB_USER` / `DB_PASSWORD` env vars (already supported by `src/config.py`).
- **release.yml:** docker job converted to matrix strategy. Builds both `memory-vault` (uses `Dockerfile`) and `memory-vault-mcp` (uses `Dockerfile.mcp`) in parallel, multi-arch (amd64 + arm64). Each image gets its own GHA cache scope to avoid layer conflicts.

## How was this tested?

Local build on linux/arm64:
- `docker build -f Dockerfile.mcp -t memory-vault-mcp:local-test --platform linux/arm64 .`
- Image: 2.22 GB (torch + sentence-transformers + spaCy dominate; FastAPI + web stripping doesn't move the needle much)
- All 80+ dependencies install cleanly, spaCy `en_core_web_sm` model downloads

Stdio smoke test:
- `echo "" | docker run --rm -i memory-vault-mcp:local-test`
- Container boots, MCP server initializes stdio loop, handles JSON-RPC errors with protocol-correct notifications

Full multi-arch CI build will run when v1.0.4 is tagged (not in this PR — release builds only trigger on tag push).

## Why this matters

- Both MCP registries refuse compose-based servers — a thin single-image variant is the only path forward for distribution
- Compounding distribution surface (multi-year, every MCP client surfaces these registries)

## Follow-up (separate work, NOT this PR)

- Issue to file: explore size optimization for the MCP image (2.22 GB is large; could explore ONNX-quantized embeddings or runtime model download)
- After this PR merges: tag v1.0.4 to trigger the first dual-image release
- After the image is published: write server.json (official MCP registry) + server.yaml (Docker MCP Toolkit) and submit 2 PRs

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] Tests pass locally — verified via local docker build + stdio smoke test
- [x] Lint passes locally — no Python source changes
- [ ] I added or updated tests for the change — N/A, Dockerfile + workflow only
- [x] I updated the README, docstrings, or FAQ if user-facing behavior changed — README update will come with the registry submission PRs (separate scope)
- [x] I did not add new dependencies without justification — no new deps; thin image, narrower runtime than the existing one
- [x] I did not log user-supplied content
