### PR TITLE
chore(mcp): add MCP Registry ownership label to Dockerfile.mcp

### DIFF
--- a/Dockerfile.mcp
+++ b/Dockerfile.mcp
@@ -12,6 +12,9 @@
 
 FROM python:3.14-slim
 
+# Ownership verification for the official MCP Registry — must match `name` in server.json
+LABEL io.modelcontextprotocol.server.name="io.github.mihaibuilds/memory-vault"
+
 WORKDIR /app
 
 # CPU-only PyTorch (sentence-transformers needs torch for embeddings)


### PR DESCRIPTION
Required prep for the official MCP Registry submission. Adds a single LABEL to Dockerfile.mcp so the registry can verify OCI image ownership at submission time.

## Summary

Adds `LABEL io.modelcontextprotocol.server.name="io.github.mihaibuilds/memory-vault"` to Dockerfile.mcp.

The registry verifies that whoever submits a server.json actually controls the image by reading this OCI annotation. Without it, our submission will be rejected at validation time.

Per https://github.com/modelcontextprotocol/registry/blob/main/docs/modelcontextprotocol-io/package-types.mdx#L155 — OCI ownership verification section.

## Related issue

N/A — implements the ownership-verification prerequisite identified during Path A registry submission prep.

## Type of change

- [x] Refactor / internal cleanup

## How was this tested?

- Diff is 3 lines, single LABEL directive
- LABELs are docker-build-time metadata; no runtime change
- Image size unchanged
- The full multi-arch build will run when v1.0.5 is tagged

## Why this PR and not just edit the existing image?

OCI labels are baked at build time. We can't retroactively add a LABEL to the published `memory-vault-mcp:1.0.4` image — needs a rebuild. Next release will be v1.0.5 which rebuilds both images with this label included.

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] Tests pass locally — no Python or web source changes
- [x] Lint passes locally
- [ ] I added or updated tests for the change — N/A, Dockerfile label only
- [x] I updated the README, docstrings, or FAQ if user-facing behavior changed — N/A, no user-facing change
- [x] I did not add new dependencies without justification
- [x] I did not log user-supplied content