### PR TITLE
chore(mcp): fix casing of MCP Registry ownership label (mihaibuilds -> MihaiBuilds)

### DIFF
--- a/Dockerfile.mcp
+++ b/Dockerfile.mcp
@@ -13,7 +13,7 @@
 FROM python:3.14-slim
 
 # Ownership verification for the official MCP Registry — must match `name` in server.json
-LABEL io.modelcontextprotocol.server.name="io.github.mihaibuilds/memory-vault"
+LABEL io.modelcontextprotocol.server.name="io.github.MihaiBuilds/memory-vault"
 
 WORKDIR /app
 


### PR DESCRIPTION
Discovered while attempting the first publish via `mcp-publisher publish` against v1.0.5: the MCP Registry compares the `io.modelcontextprotocol.server.name` label value against the GitHub login casing exactly.

## Summary

Our org login is **MihaiBuilds** (mixed case). The label was `io.github.mihaibuilds/memory-vault` (lowercase). The registry permits us to publish `io.github.MihaiBuilds/*` but rejected the lowercase variant with a 403:

```
Error: publish failed: server returned status 403:
{"detail":"You do not have permission to publish this server.
 You have permission to publish: io.github.MihaiBuilds-dev/*, io.github.MihaiBuilds/*.
 Attempting to publish: io.github.mihaibuilds/memory-vault."}
```

Fix: change `mihaibuilds` → `MihaiBuilds` in `Dockerfile.mcp`. Same change will be applied to `server.json` before submission.

## Related issue

N/A — discovered during Path A registry submission attempt against v1.0.5.

## Type of change

- [x] Bug fix

## How was this tested?

- 1-character diff, same surface as PR #30 (the label was added there with lowercase casing — fixed here)
- LABEL is metadata only, no runtime impact
- Full multi-arch build runs on v1.0.6 tag (next)

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] Tests pass locally — no Python/web source changes
- [x] Lint passes locally
- [ ] I added or updated tests for the change — N/A, Dockerfile label only
- [x] I updated the README, docstrings, or FAQ if user-facing behavior changed — N/A
- [x] I did not add new dependencies without justification
- [x] I did not log user-supplied content