### PR TITLE
chore(mcp): add server.json (official MCP Registry submission)

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.MihaiBuilds/memory-vault",
+  "title": "Memory Vault",
+  "description": "Local-first AI memory layer with hybrid search. Postgres + pgvector. Self-hosted, MIT.",
+  "websiteUrl": "https://mihaibuilds.com",
+  "repository": {
+    "url": "https://github.com/MihaiBuilds/memory-vault",
+    "source": "github"
+  },
+  "version": "1.0.6",
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/mihaibuilds/memory-vault-mcp:1.0.6",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "DB_HOST",
+          "description": "Hostname of the Postgres+pgvector instance Memory Vault connects to (e.g. 'host.docker.internal' when Postgres runs on the host, 'localhost' when running natively, or the service name when both run in compose)",
+          "isRequired": true,
+          "format": "string"
+        },
+        {
+          "name": "DB_PORT",
+          "description": "Postgres port",
+          "isRequired": true,
+          "format": "string",
+          "default": "5432"
+        },
+        {
+          "name": "DB_NAME",
+          "description": "Postgres database name",
+          "isRequired": true,
+          "format": "string",
+          "default": "memory_vault"
+        },
+        {
+          "name": "DB_USER",
+          "description": "Postgres user with read/write access to the memory vault database",
+          "isRequired": true,
+          "format": "string",
+          "default": "memory_vault"
+        },
+        {
+          "name": "DB_PASSWORD",
+          "description": "Postgres password for DB_USER",
+          "isRequired": true,
+          "isSecret": true,
+          "format": "string"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Adds the proven-working `server.json` used to publish Memory Vault to the official MCP Registry on 2026-05-18.

## Summary

The file lives at the repo root and is the source of truth for the registry-listing config.

Verified working: successfully published as **io.github.MihaiBuilds/memory-vault v1.0.6**:
https://registry.modelcontextprotocol.io/v0/servers?search=memory-vault

## Related issue

N/A — final piece of the Path A registry submission work.

## Type of change

- [x] Documentation
- [x] Refactor / internal cleanup

## For future releases

Bump the top-level \`version\` field + the OCI package \`identifier\` tag to match the new version, then run:

\`\`\`bash
mcp-publisher publish
\`\`\`

No fork or PR required — direct CLI submission.

## Sibling submission

The Docker MCP Toolkit catalog submission uses \`server.yaml\` in a separate fork (docker/mcp-registry#3608), not this file. That PR is awaiting Docker team review.

## How was this tested?

- File is the actual, validated, successfully-published declaration
- \`mcp-publisher validate\` against the live schema: ✅ passed
- \`mcp-publisher publish\` against the registry: ✅ accepted
- Live entry confirmed via API query

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] Tests pass locally — no source code changes
- [x] Lint passes locally
- [ ] I added or updated tests for the change — N/A, declaration file only
- [x] I updated the README, docstrings, or FAQ if user-facing behavior changed — N/A
- [x] I did not add new dependencies without justification
- [x] I did not log user-supplied content