### PR TITLE
chore(ci): tighten dependabot.yml grouping rules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,8 @@ updates:
     commit-message:
       prefix: "deps(python)"
     groups:
-      python-minor-and-patch:
+      python-deps:
+        patterns: ["*"]
         update-types:
           - minor
           - patch
@@ -33,7 +34,8 @@ updates:
     commit-message:
       prefix: "deps(web)"
     groups:
-      web-minor-and-patch:
+      web-deps:
+        patterns: ["*"]
         update-types:
           - minor
           - patch
@@ -43,17 +45,32 @@ updates:
     directory: "/"
     schedule:
       interval: monthly
+    open-pull-requests-limit: 3
     labels:
       - dependencies
     commit-message:
       prefix: "deps(ci)"
+    groups:
+      ci-deps:
+        patterns: ["*"]
+        update-types:
+          - minor
+          - patch
+          - major
 
-  # Docker base image
+  # Docker base images
   - package-ecosystem: docker
     directory: "/"
     schedule:
       interval: monthly
+    open-pull-requests-limit: 2
     labels:
       - dependencies
     commit-message:
       prefix: "deps(docker)"
+    groups:
+      docker-deps:
+        patterns: ["*"]
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
Addresses gaps observed during the May 17 Dependabot catchup batch (17 PRs opened where ~4 would have been correct with proper grouping).

## Summary

4 improvements to the existing dependabot.yml:

1. **Adds grouping to `github-actions` ecosystem** — 5 individual PRs (PRs #1-5 in the May 17 batch) collapse to 1 grouped PR going forward. Includes major versions because today's experience showed CI action major bumps (`metadata-action` v5→v6, `setup-node` v4→v6, etc.) are low-risk.

2. **Adds grouping to `docker` ecosystem** — minor/patch grouped. Major bumps (e.g. `python:3.11` → `python:3.14`) stay as individual PRs for eyeball review.

3. **Adds `patterns: ["*"]` to existing pip + npm groups** — hypothesis: the previous filter (only `update-types: [minor, patch]`) didn't catch `>=` constraint-widening updates in pyproject.toml. The 5 individual pip PRs (#6-10) in the May 17 batch suggest the group didn't match them. Adding the explicit `patterns: ["*"]` should fix this. We'll verify next Monday (May 25) when Dependabot runs again.

4. **Adds `open-pull-requests-limit`** to `github-actions` (3) and `docker` (2) for tighter discipline on monthly-cadence ecosystems.

5. **Normalizes group names** to `<ecosystem>-deps` for consistency.

## Related issue

N/A — implements the dependabot.yml hardening plan from the May 17 batch retrospective.

## Type of change

- [x] Refactor / internal cleanup

## How was this tested?

- YAML is structurally valid (verified via diff)
- Will be exercised on next Monday's (May 25) Dependabot scan
- If pip grouping still doesn't catch constraint-widening updates, we iterate

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] Tests pass locally — config file only
- [x] Lint passes locally
- [ ] I added or updated tests for the change — N/A, config only
- [x] I updated the README, docstrings, or FAQ if user-facing behavior changed — N/A, no user-facing change
- [x] I did not add new dependencies without justification
- [x] I did not log user-supplied content
