### PR TITLE
feat: real spaces auto-create + move_memory + supersede_memory + migrate_tags

### DIFF
--- a/migrations/004_supersede_move.sql
+++ b/migrations/004_supersede_move.sql
@@ -1,0 +1,9 @@
+-- Memory Vault — Supersede / Move support
+-- Adds is_superseded + superseded_by columns to chunks for the supersede_memory tool.
+-- The is_superseded column replaces the JSONB-based forgotten pattern for supersession.
+
+ALTER TABLE chunks
+    ADD COLUMN IF NOT EXISTS is_superseded BOOLEAN NOT NULL DEFAULT false,
+    ADD COLUMN IF NOT EXISTS superseded_by UUID REFERENCES chunks(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS chunks_superseded_idx ON chunks (is_superseded);

--- a/src/mcp/server.py
+++ b/src/mcp/server.py
@@ -5,10 +5,13 @@ Exposes memory search, storage, and management to Claude Desktop and Claude Code
 via the Model Context Protocol (stdio transport).
 
 Tools:
-    recall         — search memory with hybrid search (vector + full-text + RRF)
-    remember       — store a new memory
-    forget         — soft-delete a memory chunk
-    memory_status  — system health + statistics
+    recall           — search memory with hybrid search (vector + full-text + RRF)
+    remember         — store a new memory (auto-creates unknown spaces)
+    forget           — soft-delete a memory chunk
+    move_memory      — move a chunk to a different space without re-embedding
+    supersede_memory — replace a chunk; old is hidden from recall by default
+    migrate_tags     — migrate [space:X]-prefixed chunks to named spaces
+    memory_status    — system health + statistics
 
 Resources:
     memory://spaces — list of memory spaces
@@ -21,6 +24,7 @@ import decimal
 import hashlib
 import json
 import logging
+import re
 import sys
 import uuid
 from datetime import UTC, datetime
@@ -149,6 +153,7 @@ async def recall(
     since: str | None = None,
     limit: int = 10,
     max_tokens: int = 2000,
+    include_superseded: bool = False,
 ) -> str:
     """
     Search your memories for information relevant to a query.
@@ -164,6 +169,8 @@ async def recall(
         since: Only return memories after this date (ISO format, e.g. "2025-01-01").
         limit: Maximum number of results (default 10, max 50).
         max_tokens: Token budget for results (default 2000).
+        include_superseded: If True, include chunks that have been superseded
+                            (hidden by default). Use for audit/history.
     """
     if not await _ensure_db():
         return _dumps(
@@ -191,9 +198,10 @@ async def recall(
 
         results, variations, elapsed_ms = await hybrid_search(
             query_text=query,
-            space_ids=space_ids or None,
+            space_ids=space_ids,
             since=since_dt,
             limit=limit,
+            include_superseded=include_superseded,
         )
 
         formatted = []
@@ -262,15 +270,7 @@ async def remember(
         return _dumps({"stored": False, "error": "Database offline"})
 
     try:
-        space_row = await fetch_one("SELECT id FROM memory_spaces WHERE name = %s", (space,))
-        if not space_row:
-            available = await fetch_all("SELECT name FROM memory_spaces ORDER BY name")
-            names = [r["name"] for r in available]
-            return _dumps(
-                {"stored": False, "error": f"Unknown space '{space}'. Available: {names}"}
-            )
-
-        space_id = space_row["id"]
+        space_id = await _ensure_space(space)
 
         # Embed
         embedding = embed(text)
@@ -389,6 +389,214 @@ def _classify_memory(text: str) -> tuple[str, float]:
         return "pattern", 0.7
 
     return "fact", 0.5
+
+
+# ---------------------------------------------------------------------------
+# Space auto-create helper (shared by remember / move_memory / supersede_memory)
+# ---------------------------------------------------------------------------
+
+_SPACE_TAG_RE = re.compile(r"^\[space:([a-zA-Z0-9_-]+)\]\s*")
+
+
+async def _ensure_space(name: str) -> int:
+    """Return the space ID for `name`, creating the space if it does not exist."""
+    await execute_query(
+        "INSERT INTO memory_spaces (name) VALUES (%s) ON CONFLICT (name) DO NOTHING",
+        (name,),
+    )
+    row = await fetch_one("SELECT id FROM memory_spaces WHERE name = %s", (name,))
+    return row["id"]
+
+
+# ---------------------------------------------------------------------------
+# Tool: move_memory
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+async def move_memory(chunk_id: str, to_space: str) -> str:
+    """
+    Move a chunk to a different memory space without re-embedding.
+
+    Preserves: chunk_id, content, embedding, created_at, importance, category.
+    The chunk no longer appears in searches scoped to its original space.
+
+    Args:
+        chunk_id: UUID of the chunk to move.
+        to_space: Name of the destination space (auto-created if new).
+    """
+    if not await _ensure_db():
+        return _dumps({"success": False, "error": "Database offline"})
+
+    try:
+        row = await fetch_one("SELECT id FROM chunks WHERE id = %s", (chunk_id,))
+        if not row:
+            return _dumps({"success": False, "error": f"Chunk {chunk_id} not found."})
+
+        new_space_id = await _ensure_space(to_space)
+        await execute_query(
+            "UPDATE chunks SET space_id = %s, updated_at = now() WHERE id = %s",
+            (new_space_id, chunk_id),
+        )
+        return _dumps({"success": True, "chunk_id": chunk_id, "moved_to": to_space})
+
+    except Exception as e:
+        logger.exception("move_memory failed")
+        return _dumps({"success": False, "error": str(e)})
+
+
+# ---------------------------------------------------------------------------
+# Tool: supersede_memory
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+async def supersede_memory(old_chunk_id: str, new_text: str, space: str | None = None) -> str:
+    """
+    Replace a chunk with updated content.
+
+    The new chunk is embedded and stored. The old chunk is marked is_superseded=true
+    and excluded from recall by default. Use recall(include_superseded=True) to
+    retrieve superseded chunks for audit.
+
+    Args:
+        old_chunk_id: UUID of the chunk to supersede.
+        new_text: Replacement memory text (re-embedded).
+        space: Space for the new chunk. Defaults to the old chunk's space.
+    """
+    if not await _ensure_db():
+        return _dumps({"stored": False, "error": "Database offline"})
+
+    try:
+        old_row = await fetch_one(
+            "SELECT id, space_id, speaker, importance FROM chunks WHERE id = %s",
+            (old_chunk_id,),
+        )
+        if not old_row:
+            return _dumps({"stored": False, "error": f"Chunk {old_chunk_id} not found."})
+
+        new_space_id = await _ensure_space(space) if space else old_row["space_id"]
+
+        embedding = embed(new_text)
+        content_hash = hashlib.sha256(new_text.encode()).hexdigest()
+        category, importance = _classify_memory(new_text)
+        meta = json.dumps({
+            "category": category,
+            "source": "mcp",
+            "content_hash": content_hash,
+            "supersedes": old_chunk_id,
+        })
+        new_chunk_id = str(uuid.uuid4())
+        await execute_query(
+            """INSERT INTO chunks
+                   (id, space_id, chunk_index, speaker, content, embedding,
+                    source, importance, metadata)
+               VALUES (%s, %s, 0, %s, %s, %s::vector, %s, %s, %s::jsonb)""",
+            (
+                new_chunk_id, new_space_id,
+                old_row["speaker"] or "human",
+                new_text, str(embedding),
+                "mcp:supersede",
+                importance, meta,
+            ),
+        )
+        await execute_query(
+            "UPDATE chunks SET is_superseded = true, superseded_by = %s, updated_at = now() "
+            "WHERE id = %s",
+            (new_chunk_id, old_chunk_id),
+        )
+        return _dumps({
+            "stored": True,
+            "new_chunk_id": new_chunk_id,
+            "superseded_chunk_id": old_chunk_id,
+            "message": f"Superseded {old_chunk_id!r} → {new_chunk_id!r}",
+        })
+
+    except Exception as e:
+        logger.exception("supersede_memory failed")
+        return _dumps({"stored": False, "error": str(e)})
+
+
+# ---------------------------------------------------------------------------
+# Tool: migrate_tags
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+async def migrate_tags() -> str:
+    """
+    Migrate [space:X]-prefixed chunks from `default` to their named spaces.
+
+    For each chunk in `default` whose content starts with `[space:X]`:
+      1. Ensure space X exists (auto-created if new).
+      2. Move the chunk to space X (update space_id).
+      3. Strip the `[space:X]` prefix and re-embed the stripped content.
+
+    Untagged chunks and chunks already outside `default` are skipped.
+    Idempotent: a second run finds no tagged chunks and returns moved=0.
+
+    Returns: {"moved": N, "skipped_untagged": M}
+    """
+    if not await _ensure_db():
+        return _dumps({"error": "Database offline"})
+
+    try:
+        rows = await fetch_all(
+            """SELECT c.id, c.content
+               FROM chunks c
+               JOIN memory_spaces ms ON ms.id = c.space_id
+               WHERE ms.name = 'default'
+                 AND c.importance > 0
+                 AND (c.metadata->>'forgotten')::boolean IS NOT TRUE
+                 AND c.is_superseded = false
+               ORDER BY c.created_at"""
+        )
+
+        moved = 0
+        skipped_untagged = 0
+
+        for row in rows:
+            m = _SPACE_TAG_RE.match(row["content"])
+            if not m:
+                skipped_untagged += 1
+                continue
+
+            target_space = m.group(1)
+            stripped = row["content"][m.end():]
+            new_space_id = await _ensure_space(target_space)
+            new_embedding = embed(stripped)
+            content_hash = hashlib.sha256(stripped.encode()).hexdigest()
+
+            await execute_query(
+                """UPDATE chunks
+                   SET space_id = %s,
+                       content = %s,
+                       embedding = %s::vector,
+                       metadata = metadata || %s::jsonb,
+                       updated_at = now()
+                   WHERE id = %s""",
+                (
+                    new_space_id,
+                    stripped,
+                    str(new_embedding),
+                    json.dumps({"content_hash": content_hash, "migrated_from_tag": True}),
+                    row["id"],
+                ),
+            )
+            moved += 1
+
+        return _dumps({
+            "moved": moved,
+            "skipped_untagged": skipped_untagged,
+            "message": (
+                f"Migrated {moved} chunk(s) to named spaces; "
+                f"{skipped_untagged} untagged chunk(s) left in default."
+            ),
+        })
+
+    except Exception as e:
+        logger.exception("migrate_tags failed")
+        return _dumps({"error": str(e)})
 
 
 # ---------------------------------------------------------------------------

--- a/src/mcp/server.py
+++ b/src/mcp/server.py
@@ -46,6 +46,7 @@ from src.models.db import (  # noqa: E402
     execute_query,
     fetch_all,
     fetch_one,
+    has_column,
     health_check,
     init_pool,
 )
@@ -397,9 +398,45 @@ def _classify_memory(text: str) -> tuple[str, float]:
 
 _SPACE_TAG_RE = re.compile(r"^\[space:([a-zA-Z0-9_-]+)\]\s*")
 
+# The real multi-space model (auto-created spaces, move_memory, supersede_memory,
+# migrate_tags) ships together with migrations/004_supersede_move.sql — bundled as
+# one upgrade in the feature branch, and gated together here. Checking for
+# `is_superseded` is a proxy for "has migration 004 been applied", used uniformly
+# below rather than probing each new column individually.
+_UPGRADE_UNAVAILABLE_SUFFIX = (
+    "unavailable until the pending schema migration "
+    "(migrations/004_supersede_move.sql) is applied to this database. "
+    "Use the [space:X] text-tag convention within the 'default' space for now "
+    "(see migrate_tags)."
+)
+
+
+async def _upgrade_schema_ready() -> bool:
+    """Whether migrations/004_supersede_move.sql has been applied to this database."""
+    return await has_column("chunks", "is_superseded")
+
 
 async def _ensure_space(name: str) -> int:
-    """Return the space ID for `name`, creating the space if it does not exist."""
+    """
+    Return the space ID for `name`.
+
+    Creating a NEW space is deferred behind the pending schema migration (see
+    `_UPGRADE_UNAVAILABLE_SUFFIX`) — until then, only ALREADY-EXISTING spaces (in
+    practice, just "default") can be resolved. Raises ValueError for an unknown
+    name so callers (remember / move_memory / supersede_memory) surface a clear
+    message instead of silently fragmenting the interim [space:X]-tag convention,
+    which stays the operative model for now.
+    """
+    row = await fetch_one("SELECT id FROM memory_spaces WHERE name = %s", (name,))
+    if row:
+        return row["id"]
+
+    if not await _upgrade_schema_ready():
+        raise ValueError(
+            f"memory space {name!r} does not exist yet, and creating new spaces is "
+            f"{_UPGRADE_UNAVAILABLE_SUFFIX}"
+        )
+
     await execute_query(
         "INSERT INTO memory_spaces (name) VALUES (%s) ON CONFLICT (name) DO NOTHING",
         (name,),
@@ -427,6 +464,9 @@ async def move_memory(chunk_id: str, to_space: str) -> str:
     """
     if not await _ensure_db():
         return _dumps({"success": False, "error": "Database offline"})
+
+    if not await _upgrade_schema_ready():
+        return _dumps({"success": False, "error": f"move_memory is {_UPGRADE_UNAVAILABLE_SUFFIX}"})
 
     try:
         row = await fetch_one("SELECT id FROM chunks WHERE id = %s", (chunk_id,))
@@ -466,6 +506,11 @@ async def supersede_memory(old_chunk_id: str, new_text: str, space: str | None =
     """
     if not await _ensure_db():
         return _dumps({"stored": False, "error": "Database offline"})
+
+    if not await _upgrade_schema_ready():
+        return _dumps(
+            {"stored": False, "error": f"supersede_memory is {_UPGRADE_UNAVAILABLE_SUFFIX}"}
+        )
 
     try:
         old_row = await fetch_one(
@@ -539,6 +584,9 @@ async def migrate_tags() -> str:
     """
     if not await _ensure_db():
         return _dumps({"error": "Database offline"})
+
+    if not await _upgrade_schema_ready():
+        return _dumps({"error": f"migrate_tags is {_UPGRADE_UNAVAILABLE_SUFFIX}"})
 
     try:
         rows = await fetch_all(

--- a/src/models/db.py
+++ b/src/models/db.py
@@ -98,6 +98,26 @@ async def fetch_all(
         return await cur.fetchall()  # type: ignore[return-value]
 
 
+async def has_column(table: str, column: str) -> bool:
+    """
+    Whether `column` exists on `table` in the connected database.
+
+    Used to detect whether a not-yet-applied migration's columns are available, so
+    callers can degrade gracefully (an interim compatibility proxy, or a clear
+    "unavailable until migration" message) instead of erroring or half-writing
+    against a database that's behind the code. No caching: called rarely (once per
+    recall/mutation call, not in a hot loop), and a schema change applied while the
+    server is running should be picked up on the very next call, not require a
+    restart to notice.
+    """
+    row = await fetch_one(
+        """SELECT 1 FROM information_schema.columns
+           WHERE table_name = %s AND column_name = %s""",
+        (table, column),
+    )
+    return row is not None
+
+
 async def health_check() -> dict[str, Any]:
     """Run a lightweight check and return pool + server status."""
     pool = await get_pool()

--- a/src/services/search.py
+++ b/src/services/search.py
@@ -17,7 +17,7 @@ from datetime import UTC, datetime
 from typing import Any
 
 from src.config import settings
-from src.models.db import execute_query, fetch_all, fetch_one
+from src.models.db import execute_query, fetch_all, fetch_one, has_column
 from src.services.embedding import _get_model, embed, embed_batch
 
 logger = logging.getLogger(__name__)
@@ -250,17 +250,29 @@ def _make_broad_variation(query: str, keywords: list[str]) -> str:
     return q
 
 
-def _build_where_clause(
+async def _build_where_clause(
     space_ids: list[int] | None,
     since: datetime | None,
     include_superseded: bool = False,
 ) -> tuple[list[str], list[Any]]:
-    """Build shared WHERE clauses for both search arms."""
+    """Build shared WHERE clauses for both search arms.
+
+    `is_superseded` (migrations/004_supersede_move.sql) is not applied to every
+    database yet — schema migration is a separate, deliberate task, scheduled
+    later. Until it lands, `importance > 0` is the interim proxy for "not
+    retired": the same signal memory_status()'s "active" count already uses.
+    Once the migration is applied, has_column() flips to True and this
+    function automatically uses the real column — no further code change
+    needed here.
+    """
     where_clauses: list[str] = ["(c.metadata->>'forgotten')::boolean IS NOT TRUE"]
     params: list[Any] = []
 
     if not include_superseded:
-        where_clauses.append("c.is_superseded = false")
+        if await has_column("chunks", "is_superseded"):
+            where_clauses.append("c.is_superseded = false")
+        else:
+            where_clauses.append("c.importance > 0")
 
     if space_ids is not None:
         if space_ids:
@@ -301,7 +313,7 @@ async def hybrid_search(
     variations = expand_query(query_text) if enrich else [query_text]
     vectors = embed_batch(variations) if len(variations) > 1 else [embed(variations[0])]
 
-    base_where, base_params = _build_where_clause(space_ids, since, include_superseded)
+    base_where, base_params = await _build_where_clause(space_ids, since, include_superseded)
 
     # --- Arm 1: Vector search (multi-variation UNION ALL) ---
 

--- a/src/services/search.py
+++ b/src/services/search.py
@@ -253,15 +253,23 @@ def _make_broad_variation(query: str, keywords: list[str]) -> str:
 def _build_where_clause(
     space_ids: list[int] | None,
     since: datetime | None,
+    include_superseded: bool = False,
 ) -> tuple[list[str], list[Any]]:
     """Build shared WHERE clauses for both search arms."""
     where_clauses: list[str] = ["(c.metadata->>'forgotten')::boolean IS NOT TRUE"]
     params: list[Any] = []
 
-    if space_ids:
-        placeholders = ", ".join(["%s"] * len(space_ids))
-        where_clauses.append(f"c.space_id IN ({placeholders})")
-        params.extend(space_ids)
+    if not include_superseded:
+        where_clauses.append("c.is_superseded = false")
+
+    if space_ids is not None:
+        if space_ids:
+            placeholders = ", ".join(["%s"] * len(space_ids))
+            where_clauses.append(f"c.space_id IN ({placeholders})")
+            params.extend(space_ids)
+        else:
+            # Caller requested specific spaces but none matched — return nothing.
+            where_clauses.append("false")
 
     if since:
         where_clauses.append("c.created_at >= %s")
@@ -277,6 +285,7 @@ async def hybrid_search(
     limit: int | None = None,
     *,
     enrich: bool = True,
+    include_superseded: bool = False,
 ) -> tuple[list[SearchResult], list[str], int]:
     """
     Hybrid search: vector (HNSW) + full-text (tsvector GIN) + RRF merging.
@@ -292,7 +301,7 @@ async def hybrid_search(
     variations = expand_query(query_text) if enrich else [query_text]
     vectors = embed_batch(variations) if len(variations) > 1 else [embed(variations[0])]
 
-    base_where, base_params = _build_where_clause(space_ids, since)
+    base_where, base_params = _build_where_clause(space_ids, since, include_superseded)
 
     # --- Arm 1: Vector search (multi-variation UNION ALL) ---
 

--- a/tests/test_recall_schema_compat.py
+++ b/tests/test_recall_schema_compat.py
@@ -1,0 +1,232 @@
+"""
+Interim schema-compatibility tests (2026-07-03).
+
+migrations/004_supersede_move.sql (is_superseded / superseded_by) has NOT been
+applied to the live production database — that's a separate, deliberate task
+scheduled later (MEMORY_VAULT_UPGRADE_SPEC). Until then:
+
+  * recall() must not hard-reference `is_superseded` — it errored in production
+    with "column c.is_superseded does not exist". Fixed via has_column() +
+    an importance>0 interim proxy (the same signal memory_status()'s "active"
+    count already uses).
+  * supersede_memory / move_memory / migrate_tags / _ensure_space's auto-create
+    are all "ahead of the schema" and must fail gracefully (a clear message,
+    zero writes) rather than error or half-write, when the column is missing.
+
+These tests run against the SAME migrated `memory_vault_test` database as the
+rest of the suite (see conftest.py) — has_column() genuinely returns True
+there, so the "column missing" scenarios below mock has_column() directly
+rather than standing up a second, un-migrated test database. This also proves
+the existing test_spaces_move_supersede.py suite's "migrated" expectations are
+untouched: those tests keep passing unchanged because has_column() truthfully
+reports the column exists in THIS database.
+
+Integration: requires PostgreSQL (see conftest.py's _test_database fixture).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+
+async def _false(table: str, column: str) -> bool:
+    return False
+
+
+async def _true(table: str, column: str) -> bool:
+    return True
+
+
+# ---------------------------------------------------------------------------
+# has_column() itself
+# ---------------------------------------------------------------------------
+
+
+class TestHasColumn:
+    @pytest.mark.asyncio
+    async def test_true_for_a_column_that_exists(self):
+        from src.models.db import has_column
+
+        assert await has_column("chunks", "is_superseded") is True
+
+    @pytest.mark.asyncio
+    async def test_false_for_a_column_that_does_not_exist(self):
+        from src.models.db import has_column
+
+        assert await has_column("chunks", "definitely_not_a_real_column_xyz") is False
+
+    @pytest.mark.asyncio
+    async def test_false_for_a_table_that_does_not_exist(self):
+        from src.models.db import has_column
+
+        assert await has_column("no_such_table_xyz", "id") is False
+
+
+# ---------------------------------------------------------------------------
+# _build_where_clause — the recall() fix itself
+# ---------------------------------------------------------------------------
+
+
+class TestBuildWhereClause:
+    @pytest.mark.asyncio
+    async def test_uses_is_superseded_when_column_exists(self, monkeypatch):
+        from src.services import search
+
+        monkeypatch.setattr(search, "has_column", _true)
+        clauses, _params = await search._build_where_clause(None, None, include_superseded=False)
+        assert "c.is_superseded = false" in clauses
+        assert not any("importance" in c for c in clauses)
+
+    @pytest.mark.asyncio
+    async def test_uses_importance_proxy_when_column_missing(self, monkeypatch):
+        """The exact regression guard for the production bug: recall() must NEVER emit
+        `is_superseded` in its SQL when the column doesn't exist on this database."""
+        from src.services import search
+
+        monkeypatch.setattr(search, "has_column", _false)
+        clauses, _params = await search._build_where_clause(None, None, include_superseded=False)
+        assert "c.importance > 0" in clauses
+        assert not any("is_superseded" in c for c in clauses)
+
+    @pytest.mark.asyncio
+    async def test_include_superseded_skips_both_checks_regardless_of_schema(self, monkeypatch):
+        from src.services import search
+
+        for fake in (_true, _false):
+            monkeypatch.setattr(search, "has_column", fake)
+            clauses, _params = await search._build_where_clause(None, None, include_superseded=True)
+            joined = " ".join(clauses)
+            assert "is_superseded" not in joined
+            assert "importance" not in joined
+
+    @pytest.mark.asyncio
+    async def test_forgotten_check_is_always_present_regardless_of_schema(self, monkeypatch):
+        from src.services import search
+
+        for fake in (_true, _false):
+            monkeypatch.setattr(search, "has_column", fake)
+            clauses, _params = await search._build_where_clause(
+                None, None, include_superseded=False
+            )
+            assert "(c.metadata->>'forgotten')::boolean IS NOT TRUE" in clauses
+
+
+# ---------------------------------------------------------------------------
+# recall() / memory_status() — end-to-end, must work against this database
+# ---------------------------------------------------------------------------
+
+
+class TestRecallAndStatusWork:
+    @pytest.mark.asyncio
+    async def test_recall_returns_ranked_results(self):
+        from src.mcp.server import recall, remember
+
+        await remember("unique_token_SCHEMACOMPAT1 a fact about recall working")
+        result = json.loads(await recall("unique_token_SCHEMACOMPAT1"))
+        assert result["status"] == "ok"
+        assert len(result["results"]) >= 1
+
+    @pytest.mark.asyncio
+    async def test_recall_excludes_zero_importance_chunks_when_column_missing(self, monkeypatch):
+        """Same behavior recall() already has via is_superseded, reached through the interim
+        importance>0 proxy: a forgotten (importance=0) chunk stays hidden by default."""
+        from src.mcp import server
+        from src.services import search
+
+        r = json.loads(await server.remember("unique_token_SCHEMACOMPAT2 forgettable"))
+        chunk_id = r["chunk_id"]
+        await server.forget(chunk_id)
+
+        monkeypatch.setattr(search, "has_column", _false)
+        result = json.loads(await server.recall("unique_token_SCHEMACOMPAT2"))
+        ids = [item["chunk_id"] for item in result["results"]]
+        assert chunk_id not in ids
+
+    @pytest.mark.asyncio
+    async def test_memory_status_stays_online(self):
+        from src.mcp.server import memory_status
+
+        status = json.loads(await memory_status())
+        assert status["status"] == "online"
+        assert status["database"] == "connected"
+        assert isinstance(status["total_chunks"], int)
+        assert isinstance(status["active_chunks"], int)
+
+
+# ---------------------------------------------------------------------------
+# Guards: supersede_memory / move_memory / migrate_tags / auto-create space
+# ---------------------------------------------------------------------------
+
+
+class TestGuardsWhenSchemaNotReady:
+    @pytest.mark.asyncio
+    async def test_move_memory_guarded(self, monkeypatch):
+        from src.mcp import server
+
+        r = json.loads(await server.remember("payload for move guard test GUARDMOVE1"))
+        chunk_id = r["chunk_id"]
+
+        monkeypatch.setattr(server, "has_column", _false)
+        result = json.loads(await server.move_memory(chunk_id, "some_new_space"))
+        assert result.get("success") is False
+        assert "migration" in result.get("error", "").lower()
+
+    @pytest.mark.asyncio
+    async def test_supersede_memory_guarded(self, monkeypatch):
+        from src.mcp import server
+
+        r = json.loads(await server.remember("payload for supersede guard GUARDSUP1"))
+        old_id = r["chunk_id"]
+
+        monkeypatch.setattr(server, "has_column", _false)
+        result = json.loads(await server.supersede_memory(old_id, "new text GUARDSUP1"))
+        assert result.get("stored") is False
+        assert "migration" in result.get("error", "").lower()
+
+    @pytest.mark.asyncio
+    async def test_supersede_memory_no_half_write_when_guarded(self, monkeypatch):
+        """The precise concern the task named: supersede_memory must not create a new chunk
+        and THEN fail — it must do zero writes when the schema isn't ready."""
+        from src.mcp import server
+        from src.models.db import fetch_one
+
+        r = json.loads(await server.remember("payload for half-write check GUARDSUP2"))
+        old_id = r["chunk_id"]
+        before = await fetch_one("SELECT COUNT(*) AS n FROM chunks")
+
+        monkeypatch.setattr(server, "has_column", _false)
+        await server.supersede_memory(old_id, "new text GUARDSUP2")
+
+        after = await fetch_one("SELECT COUNT(*) AS n FROM chunks")
+        assert after["n"] == before["n"], "no new chunk should be created (no half-write)"
+
+    @pytest.mark.asyncio
+    async def test_migrate_tags_guarded(self, monkeypatch):
+        from src.mcp import server
+
+        monkeypatch.setattr(server, "has_column", _false)
+        result = json.loads(await server.migrate_tags())
+        assert "migration" in result.get("error", "").lower()
+
+    @pytest.mark.asyncio
+    async def test_remember_new_space_guarded(self, monkeypatch):
+        from src.mcp import server
+
+        monkeypatch.setattr(server, "has_column", _false)
+        result = json.loads(
+            await server.remember("payload GUARDSPACE1", space="brand_new_space_guard1")
+        )
+        assert result.get("stored") is False
+        assert "migration" in result.get("error", "").lower()
+
+    @pytest.mark.asyncio
+    async def test_remember_existing_default_space_still_works_when_guarded(self, monkeypatch):
+        """The guard blocks CREATING new spaces, not using the one that already exists."""
+        from src.mcp import server
+
+        monkeypatch.setattr(server, "has_column", _false)
+        result = json.loads(await server.remember("payload GUARDSPACE2 default still works"))
+        assert result.get("stored") is True
+        assert result.get("space") == "default"

--- a/tests/test_spaces_move_supersede.py
+++ b/tests/test_spaces_move_supersede.py
@@ -1,0 +1,321 @@
+"""
+TDD tests for memory-vault upgrade spec (2026-06-30):
+  1. Real spaces — auto-create on write; recall is a hard filter
+  2. move_memory tool — change space in place, preserve chunk_id / embedding
+  3. supersede_memory tool — hide old, surface new; include_superseded opt-in
+  4. migrate_tags tool — move [space:X]-prefixed chunks to real spaces, strip tag
+
+Tests are written BEFORE implementation.  Confirm RED, then implement.
+
+Integration: requires PostgreSQL (migration 004 applied via _test_database fixture).
+Run with: DB_HOST=127.0.0.1 pytest tests/test_spaces_move_supersede.py -v
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+import pytest_asyncio
+
+# ---------------------------------------------------------------------------
+# Fixture: ensure server._db_ready is True so tool functions skip init_pool
+# (conftest._test_database already initialised the pool)
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _patch_db_ready():
+    from src.mcp import server
+
+    server._db_ready = True
+    yield
+    server._db_ready = False
+
+
+# ---------------------------------------------------------------------------
+# 1. Real spaces — auto-create on write
+# ---------------------------------------------------------------------------
+
+
+class TestAutoCreateSpace:
+    @pytest.mark.asyncio
+    async def test_remember_creates_new_space_instead_of_rejecting(self):
+        from src.mcp.server import remember
+
+        result = json.loads(await remember("payload for brand_new_space", space="brand_new_space"))
+        assert result.get("stored") is True, f"expected stored=True, got {result}"
+        assert result.get("space") == "brand_new_space"
+
+    @pytest.mark.asyncio
+    async def test_new_space_visible_in_memory_status(self):
+        from src.mcp.server import memory_status, remember
+
+        await remember("payload for statusspace", space="statusspace")
+        status = json.loads(await memory_status())
+        assert "statusspace" in status["chunks_per_space"], (
+            f"statusspace not found in {list(status['chunks_per_space'].keys())}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_recall_from_new_space_returns_the_stored_chunk(self):
+        from src.mcp.server import recall, remember
+
+        r = json.loads(await remember("unique_token_XYZ987 recall new space", space="recallspace"))
+        chunk_id = r["chunk_id"]
+        result = json.loads(await recall("unique_token_XYZ987", spaces=["recallspace"]))
+        ids = [item["chunk_id"] for item in result["results"]]
+        assert chunk_id in ids
+
+    @pytest.mark.asyncio
+    async def test_recall_hard_filter_excludes_other_spaces(self):
+        """A chunk stored in spaceA must NOT appear when recalling from spaceB."""
+        from src.mcp.server import recall, remember
+
+        r = json.loads(await remember("exclusive_ABC content in spaceA", space="spaceA"))
+        chunk_id = r["chunk_id"]
+        result = json.loads(await recall("exclusive_ABC content", spaces=["spaceB"]))
+        ids = [item["chunk_id"] for item in result["results"]]
+        assert chunk_id not in ids, "chunk from spaceA must not appear when filtering to spaceB"
+
+
+# ---------------------------------------------------------------------------
+# 2. move_memory
+# ---------------------------------------------------------------------------
+
+
+class TestMoveMemory:
+    @pytest.mark.asyncio
+    async def test_move_memory_changes_space(self):
+        from src.mcp.server import move_memory, recall, remember
+
+        r = json.loads(await remember("payload to be moved MOVE1"))
+        chunk_id = r["chunk_id"]
+        move_r = json.loads(await move_memory(chunk_id, "dest_space_1"))
+        assert move_r.get("success") is True, f"move failed: {move_r}"
+        result = json.loads(await recall("payload to be moved MOVE1", spaces=["dest_space_1"]))
+        ids = [item["chunk_id"] for item in result["results"]]
+        assert chunk_id in ids
+
+    @pytest.mark.asyncio
+    async def test_move_memory_removes_from_original_space(self):
+        from src.mcp.server import move_memory, recall, remember
+
+        r = json.loads(await remember("leave default MOVE2"))
+        chunk_id = r["chunk_id"]
+        await move_memory(chunk_id, "elsewhere_2")
+        result = json.loads(await recall("leave default MOVE2", spaces=["default"]))
+        ids = [item["chunk_id"] for item in result["results"]]
+        assert chunk_id not in ids, "chunk should no longer appear under default after move"
+
+    @pytest.mark.asyncio
+    async def test_move_memory_preserves_chunk_id_and_content(self):
+        from src.mcp.server import move_memory, remember
+
+        from src.models.db import fetch_one
+
+        r = json.loads(await remember("preserve_content MOVE3"))
+        chunk_id = r["chunk_id"]
+        await move_memory(chunk_id, "preserve_dest")
+        row = await fetch_one("SELECT content FROM chunks WHERE id = %s", (chunk_id,))
+        assert row is not None
+        assert "preserve_content MOVE3" in row["content"]
+
+    @pytest.mark.asyncio
+    async def test_move_memory_preserves_embedding(self):
+        """Embedding vector must be unchanged after move (no re-embed)."""
+        from src.mcp.server import move_memory, remember
+
+        from src.models.db import fetch_one
+
+        r = json.loads(await remember("embedding preserved MOVE4"))
+        chunk_id = r["chunk_id"]
+        row_before = await fetch_one(
+            "SELECT embedding::text AS emb FROM chunks WHERE id = %s", (chunk_id,)
+        )
+        await move_memory(chunk_id, "emb_dest")
+        row_after = await fetch_one(
+            "SELECT embedding::text AS emb FROM chunks WHERE id = %s", (chunk_id,)
+        )
+        assert row_before["emb"] == row_after["emb"], "embedding must not change after move"
+
+    @pytest.mark.asyncio
+    async def test_move_memory_nonexistent_chunk_returns_failure(self):
+        from src.mcp.server import move_memory
+
+        result = json.loads(await move_memory("00000000-0000-0000-0000-000000000000", "anywhere"))
+        assert result.get("success") is False
+
+    @pytest.mark.asyncio
+    async def test_move_memory_auto_creates_target_space(self):
+        from src.mcp.server import move_memory, remember
+
+        from src.models.db import fetch_one
+
+        r = json.loads(await remember("auto create target MOVE5"))
+        chunk_id = r["chunk_id"]
+        await move_memory(chunk_id, "autocreated_dest_space")
+        row = await fetch_one(
+            "SELECT id FROM memory_spaces WHERE name = %s", ("autocreated_dest_space",)
+        )
+        assert row is not None, "target space should have been auto-created"
+
+
+# ---------------------------------------------------------------------------
+# 3. supersede_memory
+# ---------------------------------------------------------------------------
+
+
+class TestSupersedeMemory:
+    @pytest.mark.asyncio
+    async def test_supersede_stores_new_chunk(self):
+        from src.mcp.server import remember, supersede_memory
+
+        r = json.loads(await remember("old fact SUP1"))
+        old_id = r["chunk_id"]
+        sup = json.loads(await supersede_memory(old_id, "new fact SUP1"))
+        assert sup.get("stored") is True, f"expected stored=True, got {sup}"
+        assert "new_chunk_id" in sup
+
+    @pytest.mark.asyncio
+    async def test_supersede_hides_old_chunk_from_default_recall(self):
+        from src.mcp.server import recall, remember, supersede_memory
+
+        r = json.loads(await remember("supersedable_QQQ old version"))
+        old_id = r["chunk_id"]
+        sup = json.loads(await supersede_memory(old_id, "supersedable_QQQ new version"))
+        new_id = sup["new_chunk_id"]
+        result = json.loads(await recall("supersedable_QQQ"))
+        ids = [item["chunk_id"] for item in result["results"]]
+        assert new_id in ids, "new chunk must appear in recall"
+        assert old_id not in ids, "old chunk must be hidden from default recall"
+
+    @pytest.mark.asyncio
+    async def test_supersede_include_superseded_surfaces_old_chunk(self):
+        from src.mcp.server import recall, remember, supersede_memory
+
+        r = json.loads(await remember("visible_with_flag_WWW old"))
+        old_id = r["chunk_id"]
+        await supersede_memory(old_id, "visible_with_flag_WWW new")
+        result = json.loads(await recall("visible_with_flag_WWW", include_superseded=True))
+        ids = [item["chunk_id"] for item in result["results"]]
+        assert old_id in ids, "old chunk must appear when include_superseded=True"
+
+    @pytest.mark.asyncio
+    async def test_supersede_nonexistent_chunk_returns_failure(self):
+        from src.mcp.server import supersede_memory
+
+        result = json.loads(
+            await supersede_memory("00000000-0000-0000-0000-000000000000", "new text")
+        )
+        assert result.get("stored") is False
+
+    @pytest.mark.asyncio
+    async def test_supersede_inherits_space_of_old_chunk_by_default(self):
+        from src.mcp.server import remember, supersede_memory
+
+        from src.models.db import fetch_one
+
+        await remember("", space="inherit_space")  # ensure space exists
+        r = json.loads(await remember("old in inherit_space SUP2", space="inherit_space"))
+        old_id = r["chunk_id"]
+        sup = json.loads(await supersede_memory(old_id, "new in inherit_space SUP2"))
+        new_id = sup["new_chunk_id"]
+        row = await fetch_one(
+            "SELECT ms.name FROM chunks c JOIN memory_spaces ms ON ms.id = c.space_id "
+            "WHERE c.id = %s",
+            (new_id,),
+        )
+        assert row["name"] == "inherit_space"
+
+    @pytest.mark.asyncio
+    async def test_supersede_with_explicit_space_uses_that_space(self):
+        from src.mcp.server import remember, supersede_memory
+
+        from src.models.db import fetch_one
+
+        r = json.loads(await remember("old SUP3"))
+        old_id = r["chunk_id"]
+        sup = json.loads(await supersede_memory(old_id, "new SUP3", space="explicit_space"))
+        new_id = sup["new_chunk_id"]
+        row = await fetch_one(
+            "SELECT ms.name FROM chunks c JOIN memory_spaces ms ON ms.id = c.space_id "
+            "WHERE c.id = %s",
+            (new_id,),
+        )
+        assert row["name"] == "explicit_space"
+
+
+# ---------------------------------------------------------------------------
+# 4. migrate_tags
+# ---------------------------------------------------------------------------
+
+
+class TestMigrateTags:
+    @pytest.mark.asyncio
+    async def test_migrate_moves_tagged_chunk_to_named_space(self):
+        from src.mcp.server import migrate_tags, remember
+
+        from src.models.db import fetch_one
+
+        r = json.loads(await remember("[space:aed] AED promotion gate memory MIGT1"))
+        chunk_id = r["chunk_id"]
+        result = json.loads(await migrate_tags())
+        assert result.get("moved", 0) >= 1
+        row = await fetch_one(
+            "SELECT ms.name, c.content FROM chunks c "
+            "JOIN memory_spaces ms ON ms.id = c.space_id "
+            "WHERE c.id = %s",
+            (chunk_id,),
+        )
+        assert row["name"] == "aed"
+        assert not row["content"].startswith("[space:")
+
+    @pytest.mark.asyncio
+    async def test_migrate_strips_space_tag_from_content(self):
+        from src.mcp.server import migrate_tags, remember
+
+        from src.models.db import fetch_one
+
+        r = json.loads(await remember("[space:global] cross-project operator note MIGT2"))
+        chunk_id = r["chunk_id"]
+        await migrate_tags()
+        row = await fetch_one("SELECT content FROM chunks WHERE id = %s", (chunk_id,))
+        assert not row["content"].startswith("[space:")
+        assert "cross-project operator note MIGT2" in row["content"]
+
+    @pytest.mark.asyncio
+    async def test_migrate_leaves_untagged_chunks_in_place(self):
+        from src.mcp.server import migrate_tags, remember
+
+        from src.models.db import fetch_one
+
+        r = json.loads(await remember("untagged memory MIGT3"))
+        chunk_id = r["chunk_id"]
+        await migrate_tags()
+        row = await fetch_one(
+            "SELECT ms.name FROM chunks c "
+            "JOIN memory_spaces ms ON ms.id = c.space_id WHERE c.id = %s",
+            (chunk_id,),
+        )
+        assert row["name"] == "default"
+
+    @pytest.mark.asyncio
+    async def test_migrate_returns_moved_and_skipped_counts(self):
+        from src.mcp.server import migrate_tags, remember
+
+        await remember("[space:projx] tagged 1 MIGT4")
+        await remember("[space:projy] tagged 2 MIGT4")
+        await remember("untagged A MIGT4")
+        result = json.loads(await migrate_tags())
+        assert result.get("moved") == 2
+        assert "skipped_untagged" in result or "skipped" in result
+
+    @pytest.mark.asyncio
+    async def test_migrate_is_idempotent(self):
+        from src.mcp.server import migrate_tags, remember
+
+        await remember("[space:idm] idempotent test MIGT5")
+        await migrate_tags()
+        result = json.loads(await migrate_tags())
+        assert result.get("moved") == 0


### PR DESCRIPTION
## Summary

Implements [Memory-Vault Upgrade Spec](https://github.com/gatesl/aed/blob/main/design/MEMORY_VAULT_UPGRADE_SPEC.md) items 1–4 (hygiene/ANN in item 5 deferred).

- **Real spaces (hard isolation):** `remember(space=X)` auto-creates unknown spaces via `INSERT ... ON CONFLICT DO NOTHING`. `recall(spaces=[...])` is now a verified hard filter — an empty `space_ids` list resolves to a `false` WHERE clause (zero results) rather than falling through to all-space search.
- **`move_memory(chunk_id, to_space)`:** changes `space_id` in place; preserves `chunk_id`, `content`, and embedding (no re-embed). Auto-creates the target space.
- **`supersede_memory(old_chunk_id, new_text, space=None)`:** embeds `new_text`, inserts a new chunk, marks the old chunk `is_superseded=true`. `recall()` excludes superseded chunks by default; `recall(include_superseded=True)` surfaces them for audit.
- **`migrate_tags()`:** migrates `[space:X]`-prefixed chunks from `default` into named spaces, strips the tag prefix, and re-embeds. Idempotent.

**Migration:** `migrations/004_supersede_move.sql` adds `is_superseded` (bool, default false) and `superseded_by` (UUID FK) columns + index. The test suite applies it automatically via `run_migrations()`. **Must be applied to the production `memory_vault` DB before deploying.**

## Test plan

- 21 new TDD tests written before implementation (RED confirmed first):
  - `TestAutoCreateSpace` (4 tests): auto-create, `memory_status`, hard-filter recall
  - `TestMoveMemory` (6 tests): space change, removal from original, id/content/embedding preserved, nonexistent chunk, auto-create target
  - `TestSupersedeMemory` (6 tests): new chunk stored, old hidden, `include_superseded` surfaces old, nonexistent fails, space inheritance, explicit space override
  - `TestMigrateTags` (5 tests): move, strip tag, leave untagged, counts, idempotency
- 177 pre-existing tests unchanged
- 7 pre-existing spaCy NER failures in `test_extraction.py`/`test_graph_api.py` are unrelated and pre-date this branch (confirmed on `main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)