### PR TITLE
chore(ci): dependabot ignore majors for data-semantics packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,23 @@ updates:
       - dependencies
     commit-message:
       prefix: "deps(python)"
+    # Ignore major-version bumps for packages that touch data semantics
+    # (embeddings, NER, vector storage). Their outputs can shift silently
+    # even when CI passes; require deliberate manual upgrades with a
+    # compatibility check.
+    ignore:
+      - dependency-name: "sentence-transformers"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "spacy"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "pgvector"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "transformers"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "torch"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "numpy"
+        update-types: ["version-update:semver-major"]
     groups:
       python-deps:
         patterns: ["*"]


### PR DESCRIPTION
## Summary

Adds Dependabot ignore rules for major-version bumps on six Python packages whose outputs can shift silently across major versions even when CI passes:

- `sentence-transformers`
- `spacy`
- `pgvector`
- `transformers`
- `torch`
- `numpy`

Minor and patch bumps continue to flow through the `python-deps` group as before.

## Why

CI's test suite compares embeddings against embeddings from the same library version, so it cannot detect an embedding-space shift between the corpus (stored under version N) and new writes (using version N+1). The same reasoning applies to NER output shape (spacy), vector encoding (pgvector), and floating-point behavior (numpy/torch).

Major upgrades for these packages should be deliberate: read the changelog, run a compatibility check against a sample of the existing corpus, then upgrade manually.

## Test plan

- [x] YAML syntax is valid
- [x] Existing `python-deps` group still receives minor+patch bumps (config unchanged)
- [x] `ignore` block scoped to the pip ecosystem only — npm, GitHub Actions, and Docker ecosystems unchanged
