### PR TITLE
chore: bump compose image tag and publish major-version tag on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,7 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
             type=raw,value=latest,enable={{is_default_branch}}
           # On a tag push the default branch flag is false, so re-enable :latest explicitly:
           flavor: |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       retries: 10
 
   app:
-    image: ghcr.io/mihaibuilds/memory-vault:1.0.1
+    image: ghcr.io/mihaibuilds/memory-vault:1.0.6
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
## Summary

Two small user-facing fixes.

**1. `docker-compose.yml` bundled image tag bumped from `1.0.1` → `1.0.6`.**
The pinned tag in the bundled compose file was frozen at the day-one hotfix version. New users cloning `main` and running `docker compose up` got an image five patches behind the latest release, missing the two closed vite CVEs.

**2. Release workflow now publishes a `:{{major}}` tag on every semver release.**
Adds `type=semver,pattern={{major}}` to the metadata step. From the next release forward, `ghcr.io/mihaibuilds/memory-vault:1` will resolve to the newest `v1.x` image. A future compose bump to `:1` becomes a one-liner that then tracks patch releases automatically.

## Why not `:1` in compose now

`:1` doesn't exist on GHCR yet — the workflow only started emitting it as of this PR. Bumping compose to a tag that resolves 404 would be worse than the stale-tag state. `:1.0.6` is the correct pin for the current release; the migration to `:1` lands on the next release cycle when the tag exists.

## Test plan

- [x] `docker-compose.yml` diff: single line change, correct tag
- [x] `release.yml` diff: single line added inside the existing `tags:` block, YAML valid
- [x] No workflow behavior changes for existing tags (`:{{version}}`, `:{{major}}.{{minor}}`, `:latest` still emitted as before)
- [ ] Confirmed on next release: `ghcr.io/mihaibuilds/memory-vault:1` resolves and matches the newest `v1.x` image
