### PR TITLE
docs: polish public-facing markdown (voice, anchors, web/ pointer)

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -9,7 +9,7 @@ body:
         Memory Vault is a single-maintainer project with a deliberately small scope. Feature requests that frame a real problem are far more likely to land than ones that propose a solution in a vacuum.
 
         **Before opening:**
-        - Check the [Limitations section in the README](https://github.com/MihaiBuilds/memory-vault#limitations) — if it overlaps a documented v1.0 limitation, +1 the existing issue instead of opening a new one
+        - Check the [Limitations section in the README](https://github.com/MihaiBuilds/memory-vault#v10-limitations-honest) — if it overlaps a documented v1.0 limitation, +1 the existing issue instead of opening a new one
         - Search existing issues for duplicates
         - Big features (new endpoints, new UI pages, new integrations) need to be discussed *before* any code is written
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -164,7 +164,7 @@ Located in `src/adapters/`:
 
 - **`markdown.py`** — splits by headings, preserves structure
 - **`plaintext.py`** — paragraph-based with smart merging
-- **`claude.py`** — parses Claude conversation exports (the format Memory Vault was originally built around)
+- **`claude.py`** — parses Claude conversation exports
 
 Each adapter returns `RawChunk(text, speaker, timestamp, chunk_index, metadata, content_hash)`. New adapters (PDF, web pages) are part of the PRO tier.
 
@@ -411,7 +411,7 @@ LLM extraction couples graph quality to whichever model you happened to pick and
 Memory Vault was designed around the assumption that the primary user of this database is going to be Claude, not me. The REST API exposes the same operations for human-driven apps, but the MCP server isn't a wrapper around the REST API — both are direct paths into the same service code.
 
 **Why MIT-licensed core?**
-Your AI memory should belong to you, not a cloud platform. A genuinely-useful free tier (not crippleware) is what builds the community and trust. The PRO tier is operational/scale features that teams pay for — multi-user activation, dedup with importance decay, encrypted backups, conflict resolution, additional adapters — not capabilities withheld from individual users.
+Your AI memory should belong to you, not a cloud platform. The free tier is the full personal-memory product. The PRO tier adds operational and scale features that teams pay for — multi-user activation, dedup with importance decay, encrypted backups, conflict resolution, additional adapters.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ Every API response includes an `X-Request-ID` header. If a bug happens during an
 Use the [feature request template](.github/ISSUE_TEMPLATE/feature_request.yml). Two things make a feature request likely to land:
 
 1. **Frame the problem first, then propose a solution.** "I can't do X because Y" beats "please add Z."
-2. **Check the [Limitations section in the README](README.md#limitations).** If it overlaps with a documented v1.0 limitation, a +1 on the existing issue (or opening one) is more useful than a duplicate request.
+2. **Check the [Limitations section in the README](README.md#v10-limitations-honest).** If it overlaps with a documented v1.0 limitation, a +1 on the existing issue (or opening one) is more useful than a duplicate request.
 
 Big features (new endpoints, new UI pages, new external integrations) should be discussed in an issue *before* any code is written. Drive-by PRs for big features will likely be closed politely.
 
@@ -132,7 +132,6 @@ Memory Vault is small enough that consistency matters more than rules. The gener
 
 - Imperative mood ("add chat router", not "added chat router")
 - One logical change per commit when reasonable
-- No `Co-Authored-By` lines
 
 **What to avoid**
 

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ Once configured, Claude will have access to the memory tools. Try:
 
 > "Use memory_status to check the memory system."
 
-> "Remember that we decided to use PostgreSQL for all storage."
+> "Remember that we chose Redis for the session cache."
 
 > "Recall everything about hybrid search."
 

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -6,7 +6,7 @@ Memory Vault runs on Windows via Docker Desktop. This page covers the two issues
 
 If you see this error when starting the container (and the container exits with code 255), it's a line-ending issue, not a missing file. Windows git installs default to `core.autocrlf=true`, which can rewrite `scripts/start.sh` with `\r\n` line endings. Linux then reads the shebang as `#!/bin/sh\r` and tries to run an interpreter literally named `sh\r`.
 
-Memory Vault now ships with defensive `.gitattributes` rules and strips carriage returns inside the Docker image, so fresh clones should just work. If you cloned before this fix, or you still hit the error, run this **inside the repo** — do NOT change your global git config, it will break your other Windows projects:
+Memory Vault ships with defensive `.gitattributes` rules and strips carriage returns inside the Docker image, so fresh clones should just work. If you still hit the error, run this **inside the repo** — don't change your global git config, since that can affect your other Windows projects:
 
 ```bash
 cd memory-vault

--- a/web/README.md
+++ b/web/README.md
@@ -1,73 +1,7 @@
-# React + TypeScript + Vite
+# Memory Vault Dashboard
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+The web dashboard for Memory Vault. React 19 + Vite + TanStack Query, built into the main Docker image and served by FastAPI in production.
 
-Currently, two official plugins are available:
+For running the dev server, see the [Dashboard setup](../CONTRIBUTING.md#dashboard-setup) section in `CONTRIBUTING.md`.
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Oxc](https://oxc.rs)
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/)
-
-## React Compiler
-
-The React Compiler is not enabled on this template because of its impact on dev & build performances. To add it, see [this documentation](https://react.dev/learn/react-compiler/installation).
-
-## Expanding the ESLint configuration
-
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
-
-```js
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-
-      // Remove tseslint.configs.recommended and replace with this
-      tseslint.configs.recommendedTypeChecked,
-      // Alternatively, use this for stricter rules
-      tseslint.configs.strictTypeChecked,
-      // Optionally, add this for stylistic rules
-      tseslint.configs.stylisticTypeChecked,
-
-      // Other configs...
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
-```
-
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
-
-```js
-// eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
-
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-      // Enable lint rules for React
-      reactX.configs['recommended-typescript'],
-      // Enable lint rules for React DOM
-      reactDom.configs.recommended,
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
-```
+For architecture, see the [Web Dashboard](../ARCHITECTURE.md#web-dashboard) section in `ARCHITECTURE.md`.


### PR DESCRIPTION
## Summary

Small documentation polish across the public-facing markdown files. No behavior changes, no user-visible feature changes.

## Changes

- **`README.md`** — swap the "PostgreSQL for all storage" MCP example prompt for a more generic one (`Redis for the session cache`) so the example doesn't read as project autobiography.
- **`ARCHITECTURE.md`** — drop the "the format Memory Vault was originally built around" aside on the Claude JSON adapter; rewrite the MIT-licensed-core answer to state what the free tier is positively, without the defensive "not capabilities withheld" framing.
- **`CONTRIBUTING.md`** — remove the `No Co-Authored-By lines` bullet (it wasn't a rule contributor PRs need to care about); fix a broken anchor to the README Limitations section.
- **`web/README.md`** — replace the leftover Vite scaffold boilerplate with a five-line pointer to `CONTRIBUTING.md` (dashboard dev setup) and `ARCHITECTURE.md` (web dashboard section).
- **`docs/windows.md`** — soften the "will break your other Windows projects" line to "can affect your other Windows projects" (the original state was strictly correct but stronger than reality).
- **`.github/ISSUE_TEMPLATE/feature_request.yml`** — same broken README#limitations anchor fix as CONTRIBUTING.md.

## Why

Small-signal polish. A first-time reader browsing the public docs sees consistent voice, working anchors, and a `web/` folder that orients them to the real docs instead of showing Vite scaffold notes that were never edited after `npm create vite`.

## Test plan

- [x] All modified links resolve — verified `#dashboard-setup` in CONTRIBUTING.md and `#web-dashboard` in ARCHITECTURE.md both correspond to real headings
- [x] README anchor fix (`#v10-limitations-honest`) corresponds to `### v1.0 limitations (honest)` in README
- [x] No code or config changed
