### PR TITLE
docs: clean up code comments and docstrings

### DIFF
--- a/migrations/003_knowledge_graph.sql
+++ b/migrations/003_knowledge_graph.sql
@@ -1,9 +1,9 @@
--- Memory Vault — Knowledge Graph (M7)
--- Aligns pre-scaffolded `entities` and `relationships` tables with the
--- locked M7 schema, and adds the `entity_mentions` table.
+-- Memory Vault — Knowledge Graph
+-- Aligns the pre-scaffolded `entities` and `relationships` tables with the
+-- knowledge-graph schema, and adds the `entity_mentions` table.
 --
 -- Safe on empty tables: `entities` and `relationships` were scaffolded
--- in 001 but never populated (ingestion had no extraction before M7).
+-- in 001 but never populated (ingestion had no extraction before this migration).
 
 -- ---------------------------------------------------------------------------
 -- entities: add per-space scoping
@@ -14,7 +14,7 @@ ALTER TABLE entities
 
 DROP INDEX IF EXISTS entities_name_type_idx;
 
--- Per-space case-insensitive exact-match dedup (locked M7 rule).
+-- Per-space case-insensitive exact-match dedup for entity uniqueness.
 CREATE UNIQUE INDEX entities_name_type_space_idx
     ON entities (lower(name), type, space_id);
 
@@ -22,7 +22,7 @@ CREATE INDEX entities_space_idx ON entities (space_id);
 CREATE INDEX entities_type_idx ON entities (type);
 
 -- ---------------------------------------------------------------------------
--- relationships: rename columns to match M7 plan; add chunk provenance
+-- relationships: rename columns to match final schema; add chunk provenance
 -- ---------------------------------------------------------------------------
 
 ALTER TABLE relationships RENAME COLUMN from_entity_id TO source_entity_id;
@@ -30,7 +30,7 @@ ALTER TABLE relationships RENAME COLUMN to_entity_id   TO target_entity_id;
 ALTER TABLE relationships RENAME COLUMN rel_type       TO type;
 
 -- Chunk provenance — nullable because future manual/LLM tagging may not
--- be tied to a specific chunk. M7 extraction always populates it.
+-- be tied to a specific chunk. Auto-extraction always populates it.
 ALTER TABLE relationships
     ADD COLUMN chunk_id UUID REFERENCES chunks(id) ON DELETE CASCADE;
 
@@ -45,8 +45,7 @@ CREATE INDEX relationships_type_idx   ON relationships (type);
 
 -- ---------------------------------------------------------------------------
 -- entity_mentions: one row per (entity, chunk, location)
--- This is what "M7 extracts mentions" refers to — every entity hit in a
--- chunk produces a row here, with character offsets preserved.
+-- Every entity hit in a chunk produces a row here, with character offsets preserved.
 -- ---------------------------------------------------------------------------
 
 CREATE TABLE entity_mentions (

--- a/src/api/routers/chat.py
+++ b/src/api/routers/chat.py
@@ -14,9 +14,9 @@ Both share the same RAG pipeline:
   5. Return answer + sources (sources emitted FIRST in stream so the UI can
      render the "based on N memories" header before tokens arrive)
 
-Hard rule (lesson from central-memory 2026-03-17): Qwen3.5 thinking models are
-unusable for RAG Q&A via OpenAI-compat — always prefer LM Studio native API
-with reasoning="off", or use a non-thinking model (Qwen2.5, Llama 3).
+Hard rule: Qwen3.5 thinking models are unusable for RAG Q&A via OpenAI-compat
+— always prefer LM Studio native API with reasoning="off", or use a
+non-thinking model (Qwen2.5, Llama 3).
 """
 
 from __future__ import annotations
@@ -60,7 +60,7 @@ def _estimate_tokens(text: str) -> int:
 
 
 # ---------------------------------------------------------------------------
-# Thinking-strip (ports from central-memory routes.py:341-392)
+# Thinking-strip
 # ---------------------------------------------------------------------------
 
 

--- a/src/extraction/spacy_extractor.py
+++ b/src/extraction/spacy_extractor.py
@@ -47,7 +47,7 @@ class Entity:
 class Relationship:
     source_name: str
     target_name: str
-    type: str  # "related_to" (M7); other types reserved for future milestones
+    type: str  # "related_to"; other types reserved for future extraction work
 
 
 # Lazy-loaded module-level spaCy pipeline. None until first call or failed load.
@@ -139,12 +139,12 @@ def extract_entities(text: str) -> list[Entity]:
 def extract_relationships(entities: list[Entity], text: str) -> list[Relationship]:
     """Extract entity-to-entity relationships within a chunk.
 
-    M7 auto-extracts only `related_to` — co-occurrence of any two
-    distinct entities within the same chunk. Order is lexicographic on
+    Auto-extracts only `related_to` — co-occurrence of any two distinct
+    entities within the same chunk. Order is lexicographic on
     (source_name, target_name) for determinism; undirected semantics.
 
-    `text` is accepted but unused in M7 — reserved for future
-    directional or proximity-based extraction.
+    `text` is accepted but unused — reserved for future directional or
+    proximity-based extraction.
     """
     if not _SPACY_READY or len(entities) < 2:
         return []


### PR DESCRIPTION
## Summary

Comment-only polish across three files. No runtime behavior changes.

## Changes

- **`src/api/routers/chat.py`** — drop two references to a private origin project from module-level comments (Qwen3.5 hard-rule note; thinking-strip section header). The rules and behavior are unchanged; only the "ported from…" attribution is removed since it doesn't help a reader of this file.
- **`src/extraction/spacy_extractor.py`** — clean up three inline comments and one docstring so they describe what the code does directly, instead of tagging it with an internal shorthand.
- **`migrations/003_knowledge_graph.sql`** — same treatment for five SQL comment lines (header, dedup rule, column-rename note, chunk-provenance note, entity_mentions note).

## Why

Comments should describe what the code does, not what the code was tracked against internally. Same posture as the earlier `docs:` polish for `README.md` and `ARCHITECTURE.md`.

## Test plan

- [x] Comments only — no executable code changed
- [x] `git diff` verified: 3 files, +17 / -18 lines, all inside comments and docstrings
- [x] `pytest` + `ruff check` will run in CI as usual
