### PR TITLE
ci: matrix pytest across Python 3.11 and 3.13

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,10 +18,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Set up Python 3.14
+      - name: Set up Python 3.13
         uses: actions/setup-python@v6
         with:
-          python-version: "3.14"
+          python-version: "3.13"
           cache: pip
           cache-dependency-path: pyproject.toml
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,13 @@ concurrency:
 
 jobs:
   pytest:
-    name: pytest (Python 3.14, Postgres + pgvector)
+    name: pytest (Python ${{ matrix.python-version }}, Postgres + pgvector)
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.13"]
 
     services:
       db:
@@ -40,10 +45,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Set up Python 3.14
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v6
         with:
-          python-version: "3.14"
+          python-version: ${{ matrix.python-version }}
           cache: pip
           cache-dependency-path: pyproject.toml
 
@@ -54,9 +59,9 @@ jobs:
             ~/.cache/huggingface
             ~/.cache/torch
             ~/.cache/pip
-          key: ml-models-${{ runner.os }}-py314-v1
+          key: ml-models-${{ runner.os }}-py${{ matrix.python-version }}-v1
           restore-keys: |
-            ml-models-${{ runner.os }}-py314-
+            ml-models-${{ runner.os }}-py${{ matrix.python-version }}-
 
       - name: Install package + dev deps
         run: |


### PR DESCRIPTION
## Summary

Aligns pytest CI with the Python support range declared in `pyproject.toml` (`requires-python = ">=3.11"`).

- **`test.yml`** — matrix `[3.11, 3.13]`. The endpoints of the declared support range, run in parallel with `fail-fast: false` so a failure on one version doesn't hide problems on the other. Cache key includes the version so 3.11 and 3.13 caches stay separate.
- **`lint.yml`** — single version bumped from `3.14` → `3.13`. ruff/format checks don't benefit from a matrix; running on the newest matrix entry is sufficient.

## Why

`pyproject.toml` declares `>=3.11` — that's the public contract with users. Before this PR, CI ran a single version (3.14) that was ahead of the library ecosystem, so:

1. Dependabot PRs kept failing at `pip install` on wheel availability, not on real dependency issues (spaCy 3.8.14 has no cp314 wheels — PR #37 is the concrete example).
2. There was no CI evidence that users on 3.11 or 3.12 (the versions we say we support) would actually work.

Matrix across the range endpoints backs up the contract in CI. If the library ecosystem catches up to 3.14, adding it to the matrix is a one-line change.

## Not in this PR (deliberate)

Runtime Docker images (`Dockerfile`, `Dockerfile.mcp`) still use `python:3.14-slim`. Bumping the production runtime is a separate decision that should follow its own thread — it affects image builds, release cadence, and existing users pulling `:1` / `:latest`. That decision doesn't need to block this CI alignment.

## Test plan

- [x] YAML valid (matrix syntax + variable references)
- [x] `fail-fast: false` so both matrix legs report independently
- [x] Cache key includes `${{ matrix.python-version }}` so 3.11 and 3.13 caches don't collide
- [x] `lint.yml` doesn't need matrix — single version is sufficient
- [ ] CI green on both matrix legs (verified on this PR)
