### PR TITLE
fix: bump pyproject.toml version to 1.0.6 + add release-workflow version-guard

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,9 +12,30 @@ permissions:
   packages: write    # push to ghcr.io
 
 jobs:
+  version-guard:
+    name: Assert pyproject.toml version matches tag
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Compare pyproject.toml version to tag
+        run: |
+          # Fail early if the package version in pyproject.toml doesn't match the
+          # tag we're releasing. Prevents shipping a Docker image or GitHub release
+          # whose reported package version drifts from the git tag.
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          PYPROJECT_VERSION=$(grep -E '^version[[:space:]]*=[[:space:]]*"' pyproject.toml | head -1 | sed -E 's/^version[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/')
+          echo "Tag version:       $TAG_VERSION"
+          echo "pyproject version: $PYPROJECT_VERSION"
+          if [ "$TAG_VERSION" != "$PYPROJECT_VERSION" ]; then
+            echo "::error::pyproject.toml version ($PYPROJECT_VERSION) does not match tag ($TAG_VERSION). Bump pyproject.toml before tagging."
+            exit 1
+          fi
+
   docker:
     name: Build + push ${{ matrix.image }} (multi-arch) to ghcr.io
     runs-on: ubuntu-latest
+    needs: version-guard
     strategy:
       fail-fast: false
       matrix:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "memory-vault"
-version = "0.4.0"
+version = "1.0.6"
 description = "Local-first AI memory system with hybrid search — PostgreSQL + pgvector"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Fixes #75.

## Changes

1. Bump `pyproject.toml` version from `0.4.0` → `1.0.6` (matches current git tag).
2. Add `version-guard` job to `release.yml` — asserts `pyproject.toml` version matches `GITHUB_REF_NAME` (with leading `v` stripped) before any docker/release job runs. Workflow fails early with a clear error message if they diverge.

## Verification

Guard logic tested locally with portable POSIX regex (`[[:space:]]` instead of `\s` for BSD/GNU sed portability):

- `v1.0.6` tag + `1.0.6` pyproject → passes
- `v1.0.7` tag + `1.0.6` pyproject → correctly rejected with actionable error

YAML validated with `yaml.safe_load`.

## Notes

Chose the **assert** shape over auto-bump (per issue Fix Scope option 1) — keeps `pyproject.toml` under human control, forces the author to think about the version bump as a separate step from the tag push.

Attribution: @git-pharos surfaced the underlying drift via the diagnostic bundle in #74.
