### PR TITLE
chore: bump version to 1.0.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "memory-vault"
-version = "1.0.6"
+version = "1.0.7"
 description = "Local-first AI memory system with hybrid search — PostgreSQL + pgvector"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Bumps `pyproject.toml` version from 1.0.6 to 1.0.7 to satisfy the release-workflow version-guard added in #78. Must land before the `v1.0.7` tag is pushed, otherwise `release.yml` fails early.

## v1.0.7 contents

- **#78** — one-time `pyproject.toml` version fix (bumped from 0.4.0 to 1.0.6) + `release.yml` version-guard job that fails the release if `pyproject.toml` doesn't match the pushed tag.
- **#80** — Docker base image pinned to `python:3.13-slim` (was 3.14, which had no cp314 spaCy wheel), + dependabot ignore entry for `python` major/minor bumps.
- **#84** — packaging refactor: proper `memory_vault` package under `src/memory_vault/`, all imports and entrypoints updated, SQL migrations bundled with the wheel, `pip install memory-vault` produces a working `memory-vault` console script for the first time.
