### PR TITLE
security(web): bump transitive brace-expansion to 5.0.8 (GHSA-3jxr-9vmj-r5cp)

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1641,16 +1641,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/browserslist": {


### PR DESCRIPTION
## Summary

Bumps transitive `brace-expansion` from `5.0.6` to `5.0.8` to fix [GHSA-3jxr-9vmj-r5cp](https://github.com/advisories/GHSA-3jxr-9vmj-r5cp) — DoS via exponential-time expansion of consecutive non-expanding `{}` groups. Patched in `5.0.7`.

- Dev-only transitive dep (pulled via `minimatch`), not shipped in the Docker image or dashboard bundle
- Single instance in `web/package-lock.json`
- 8-line lockfile diff, no `package.json` change

## Test plan

- [x] `npm run build` in `web/` — successful build (827 kB gzipped 254 kB, same as baseline)
- [ ] CI green
