### PR TITLE
chore: bump version to 1.0.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "memory-vault"
-version = "1.0.7"
+version = "1.0.8"
 description = "Local-first AI memory system with hybrid search — PostgreSQL + pgvector"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

Bumps `pyproject.toml` version to `1.0.8` ahead of the `v1.0.8` release tag.

## What ships in v1.0.8

**Security**
- Bump transitive `brace-expansion` to `5.0.8` — fixes [GHSA-3jxr-9vmj-r5cp](https://github.com/advisories/GHSA-3jxr-9vmj-r5cp) DoS (#86)

**Dependencies**
- `numpy` `>=2.4.5` → `>=2.4.6` (#67)
- `structlog` `<26` → `>=26.1.0,<27` (#66)
- `mcp` `>=1.27.1` → `>=1.28.1` (#70)
- `setuptools` `>=82.0.1` → `>=83.0.0` (#71)
- `uvicorn` `>=0.47.0` → `>=0.51.0` (#82)
- CI actions group: `setup-node` v6 → v7, `setup-python` v6 → v7 (#88)
- Web deps group: React, @tanstack/react-query, vite, postcss, eslint, typescript-eslint, tailwindcss/postcss, and 4 more patch/minor bumps (#87)

## Test plan

- [x] All 8 constituent PRs merged with CI green (ruff, eslint+tsc, vite build, pytest 3.11, pytest 3.13, CodeQL JS+Python)
- [ ] `version-guard` job on release workflow validates tag matches `pyproject.toml`
- [ ] Docker multi-arch build (`linux/amd64` + `linux/arm64`) succeeds
- [ ] Release artifacts publish
