### PR TITLE
fix(db): validate pooled connections on checkout

### DIFF
--- a/src/memory_vault/models/db.py
+++ b/src/memory_vault/models/db.py
@@ -32,6 +32,10 @@ async def init_pool(min_size: int = 2, max_size: int = 10) -> AsyncConnectionPoo
         min_size=min_size,
         max_size=max_size,
         open=False,
+        # Validate liveness on checkout. Without this a connection that died
+        # while idle — common when the DB is across a network link — is handed
+        # out and the first query on it fails.
+        check=AsyncConnectionPool.check_connection,
         kwargs={"row_factory": dict_row, "autocommit": False},
     )
     await _pool.open()

--- a/tests/test_db_pool.py
+++ b/tests/test_db_pool.py
@@ -1,0 +1,40 @@
+"""Connection pool resilience."""
+
+import psycopg
+import pytest
+
+import memory_vault.models.db as db_module
+from memory_vault.config import settings
+from memory_vault.models.db import init_pool
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_pool_recovers_from_connection_killed_while_idle(monkeypatch):
+    """A connection dropped server-side must not surface as a query error.
+
+    Regression guard for the pool's ``check`` callback. Without it,
+    psycopg_pool hands back a connection that died while idle and the next
+    query raises — the common failure when the database sits across a
+    network link rather than on localhost.
+    """
+    # A dedicated single-connection pool, so the connection we kill is
+    # necessarily the one handed back on the next checkout.
+    monkeypatch.setattr(db_module, "_pool", None)
+    pool = await init_pool(min_size=1, max_size=1)
+
+    try:
+        async with pool.connection() as conn:
+            cur = await conn.execute("SELECT pg_backend_pid() AS pid")
+            pid = (await cur.fetchone())["pid"]
+
+        # Terminate it from an independent connection, standing in for an
+        # idle timeout, network blip, or administrator shutdown.
+        with psycopg.connect(settings.database_url, autocommit=True) as killer:
+            killer.execute("SELECT pg_terminate_backend(%s)", (pid,))
+
+        async with pool.connection() as conn:
+            cur = await conn.execute("SELECT 1 AS ok")
+            assert (await cur.fetchone())["ok"] == 1
+    finally:
+        await pool.close()


### PR DESCRIPTION
## Problem

`AsyncConnectionPool` is built without a `check` callable, so the pool hands out connections without verifying they are alive. A connection that died while sitting idle in the pool — idle timeout, network blip, administrator shutdown — is given to the caller, and the first query on it raises.

The pool's existing safeguards don't cover this case: `max_lifetime` (1h) and `max_idle` (10m) recycle connections on a timer, and a connection found broken when it is *returned* to the pool is discarded, but nothing validates a connection that died while pooled. `max_idle` also only reaps connections *above* `min_size`.

## Why it shows up in practice

This is easy to miss on localhost and routine once Postgres is across a network link — which is the normal deployment for the MCP server, since it runs on each client and connects directly to Postgres (see `DB_HOST` in `mcp.json.example`).

`memory_vault/mcp/server.py` calls `init_pool(min_size=1, max_size=5)`, so the MCP process holds a single long-lived connection that sits idle between tool calls. When that one connection dies, the next `recall`/`remember` fails:

```
consuming input failed: server closed the connection unexpectedly
```

A plain retry then succeeds, which makes it look like a transient blip rather than a missing pool setting.

I ran into this running the vault over a Tailscale link with the database on another host.

## Reproduction

```python
import asyncio, os, psycopg
from psycopg.rows import dict_row
from psycopg_pool import AsyncConnectionPool

URL = os.environ["DATABASE_URL"]

async def run(use_check: bool) -> str:
    pool = AsyncConnectionPool(
        URL, min_size=1, max_size=1, open=False,
        check=AsyncConnectionPool.check_connection if use_check else None,
        kwargs={"row_factory": dict_row},
    )
    await pool.open()
    async with pool.connection() as c:
        pid = (await (await c.execute("select pg_backend_pid() as pid")).fetchone())["pid"]

    # kill it from an independent connection: stands in for an idle drop
    with psycopg.connect(URL) as k:
        k.execute("select pg_terminate_backend(%s)", (pid,))
        k.commit()
    await asyncio.sleep(1)

    try:
        async with pool.connection() as c:
            await (await c.execute("select 1 as ok")).fetchone()
        return "RECOVERED - query succeeded"
    except Exception as e:
        return f"FAILED - {type(e).__name__}: {str(e).strip().splitlines()[0]}"
    finally:
        await pool.close()

async def main():
    for f in (False, True):
        print(f"  check={'check_connection' if f else 'None':18} -> {await run(f)}")

asyncio.run(main())
```

```
  check=None               -> FAILED - AdminShutdown: terminating connection due to administrator command
  check=check_connection   -> RECOVERED - query succeeded
```

## Fix

Pass the pool's own `check_connection` helper, so a dead connection is discarded and replaced transparently at checkout. One line, no new dependency.

## Test

`tests/test_db_pool.py` takes the backend PID of a pooled connection, terminates it from an independent connection, and asserts the next query still succeeds. I confirmed it fails with `AdminShutdown` when the fix is reverted, so it genuinely guards the behaviour rather than passing regardless.

## Scope notes

- **This does not add query retries.** psycopg_pool deliberately doesn't retry, and blind-retrying writes isn't safe — a drop during commit is ambiguous about whether it landed. This change only guarantees the connection handed out is alive.
- **TCP keepalives left out on purpose.** Adding `keepalives`/`keepalives_idle` to the conninfo would reduce how often connections die on networked deployments, but it changes behaviour for localhost users who don't need it. Happy to open that separately if you'd want it.
- Cost is one cheap round-trip per checkout.

Full suite passes locally apart from pre-existing `test_extraction.py` / `test_graph_api.py` failures caused by `en_core_web_sm` not being installed in my environment — unrelated to this change.
