### PR TITLE
chore: release v1.0.9 — pool checkout fix + version drift sweep

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,22 +13,43 @@ permissions:
 
 jobs:
   version-guard:
-    name: Assert pyproject.toml version matches tag
+    name: Assert every version surface matches tag
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
 
-      - name: Compare pyproject.toml version to tag
+      - name: Compare every version surface to the tag
         run: |
-          # Fail early if the package version in pyproject.toml doesn't match the
-          # tag we're releasing. Prevents shipping a Docker image or GitHub release
-          # whose reported package version drifts from the git tag.
+          # Every surface that reports a version must match the git tag we're
+          # releasing. Prevents shipping a Docker image, MCP registry descriptor,
+          # or release asset whose version drifts from the tag.
           TAG_VERSION="${GITHUB_REF_NAME#v}"
+          echo "Tag version: $TAG_VERSION"
+
+          fail=0
+          check() {
+            local label="$1" value="$2"
+            echo "$label: $value"
+            if [ "$value" != "$TAG_VERSION" ]; then
+              echo "::error::$label ($value) does not match tag ($TAG_VERSION)."
+              fail=1
+            fi
+          }
+
           PYPROJECT_VERSION=$(grep -E '^version[[:space:]]*=[[:space:]]*"' pyproject.toml | head -1 | sed -E 's/^version[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/')
-          echo "Tag version:       $TAG_VERSION"
-          echo "pyproject version: $PYPROJECT_VERSION"
-          if [ "$TAG_VERSION" != "$PYPROJECT_VERSION" ]; then
-            echo "::error::pyproject.toml version ($PYPROJECT_VERSION) does not match tag ($TAG_VERSION). Bump pyproject.toml before tagging."
+          check "pyproject.toml"                    "$PYPROJECT_VERSION"
+
+          COMPOSE_APP_TAG=$(grep -E 'image:[[:space:]]+ghcr\.io/mihaibuilds/memory-vault:' docker-compose.yml | head -1 | sed -E 's/.*memory-vault:([^[:space:]]+).*/\1/')
+          check "docker-compose.yml app image tag"  "$COMPOSE_APP_TAG"
+
+          SERVER_JSON_VERSION=$(python -c "import json; print(json.load(open('server.json'))['version'])")
+          check "server.json version"               "$SERVER_JSON_VERSION"
+
+          SERVER_JSON_MCP_TAG=$(python -c "import json; print(json.load(open('server.json'))['packages'][0]['identifier'].rsplit(':', 1)[1])")
+          check "server.json MCP image tag"         "$SERVER_JSON_MCP_TAG"
+
+          if [ "$fail" -ne 0 ]; then
+            echo "::error::One or more version surfaces drift from the tag. Bump every drifted file before re-tagging."
             exit 1
           fi
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       retries: 10
 
   app:
-    image: ghcr.io/mihaibuilds/memory-vault:1.0.6
+    image: ghcr.io/mihaibuilds/memory-vault:1.0.9
     depends_on:
       db:
         condition: service_healthy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "memory-vault"
-version = "1.0.8"
+version = "1.0.9"
 description = "Local-first AI memory system with hybrid search — PostgreSQL + pgvector"
 readme = "README.md"
 license = "MIT"

--- a/server.json
+++ b/server.json
@@ -8,11 +8,11 @@
     "url": "https://github.com/MihaiBuilds/memory-vault",
     "source": "github"
   },
-  "version": "1.0.6",
+  "version": "1.0.9",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/mihaibuilds/memory-vault-mcp:1.0.6",
+      "identifier": "ghcr.io/mihaibuilds/memory-vault-mcp:1.0.9",
       "transport": {
         "type": "stdio"
       },

--- a/src/memory_vault/__init__.py
+++ b/src/memory_vault/__init__.py
@@ -1,0 +1,10 @@
+"""Memory Vault package."""
+
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("memory-vault")
+except PackageNotFoundError:
+    __version__ = "unknown"
+
+__all__ = ["__version__"]

--- a/src/memory_vault/api/app.py
+++ b/src/memory_vault/api/app.py
@@ -18,6 +18,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 
+from memory_vault import __version__
 from memory_vault.api.deps import RateLimitMiddleware
 from memory_vault.api.middleware import RequestIDMiddleware
 from memory_vault.api.routers import chat, chunks, graph, health, ingest, search, spaces
@@ -46,7 +47,7 @@ def create_app() -> FastAPI:
             "Local-first AI memory system — hybrid search, ingestion, "
             "and management for your personal memory store."
         ),
-        version="0.4.0",
+        version=__version__,
         lifespan=_lifespan,
         docs_url="/docs",
         redoc_url="/redoc",

--- a/src/memory_vault/api/routers/health.py
+++ b/src/memory_vault/api/routers/health.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from fastapi import APIRouter
 
+from memory_vault import __version__
 from memory_vault.api.schemas import HealthResponse
 from memory_vault.models.db import health_check
 from memory_vault.services.embedding import MODEL_NAME
@@ -19,5 +20,5 @@ async def get_health() -> HealthResponse:
         status="ok" if db["status"] == "healthy" else "degraded",
         database="connected" if db["status"] == "healthy" else "error",
         embedding_model=MODEL_NAME,
-        version="0.4.0",
+        version=__version__,
     )

--- a/src/memory_vault/diagnose.py
+++ b/src/memory_vault/diagnose.py
@@ -95,19 +95,13 @@ def _collect_env() -> dict[str, str]:
 
 
 def _read_version() -> str:
-    pyproject = Path(__file__).resolve().parent.parent / "pyproject.toml"
-    if not pyproject.exists():
-        return "unknown"
-    try:
-        for line in pyproject.read_text().splitlines():
-            line = line.strip()
-            if line.startswith("version"):
-                # version = "0.4.0"
-                return line.split("=", 1)[1].strip().strip('"').strip("'")
-    except OSError:
-        # pyproject.toml unreadable — return "unknown" rather than crash diagnostics.
-        pass
-    return "unknown"
+    # Read from installed package metadata rather than the source tree's
+    # pyproject.toml — the src/-layout package doesn't ship pyproject.toml
+    # inside the wheel, so the old path-based lookup returned "unknown" on
+    # every pip-installed deployment.
+    from memory_vault import __version__
+
+    return __version__
 
 
 def _run(cmd: list[str], timeout: float = 10.0) -> tuple[int, str]:

--- a/tests/test_version_reporting.py
+++ b/tests/test_version_reporting.py
@@ -1,0 +1,76 @@
+"""Version-reporting agreement.
+
+Every surface that reports a Memory Vault version must agree with the
+canonical installed-package version. Regression guard for #97.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from memory_vault import __version__
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def test_installed_version_is_a_real_semver_string():
+    """__version__ resolves via importlib.metadata rather than falling back to 'unknown'."""
+    assert __version__ != "unknown", (
+        "memory_vault.__version__ resolved to 'unknown' — the package is not installed "
+        "in the test environment; run `pip install -e .` first."
+    )
+    assert re.fullmatch(r"\d+\.\d+\.\d+(?:[.\-+].+)?", __version__), (
+        f"__version__ {__version__!r} is not a semver-shaped string"
+    )
+
+
+def test_pyproject_version_matches_installed():
+    """pyproject.toml is the source of truth — importlib.metadata must reflect it."""
+    text = (REPO_ROOT / "pyproject.toml").read_text()
+    match = re.search(r'^version\s*=\s*"([^"]+)"', text, re.MULTILINE)
+    assert match is not None, "pyproject.toml has no version line"
+    assert match.group(1) == __version__
+
+
+def test_docker_compose_app_image_tag_matches_installed():
+    text = (REPO_ROOT / "docker-compose.yml").read_text()
+    match = re.search(r"ghcr\.io/mihaibuilds/memory-vault:([^\s]+)", text)
+    assert match is not None, "docker-compose.yml has no memory-vault image reference"
+    assert match.group(1) == __version__
+
+
+def test_server_json_version_matches_installed():
+    data = json.loads((REPO_ROOT / "server.json").read_text())
+    assert data["version"] == __version__
+
+
+def test_server_json_mcp_image_tag_matches_installed():
+    data = json.loads((REPO_ROOT / "server.json").read_text())
+    identifier = data["packages"][0]["identifier"]
+    assert identifier.endswith(f":{__version__}"), (
+        f"server.json packages[0].identifier is {identifier!r}, expected suffix :{__version__}"
+    )
+
+
+def test_fastapi_openapi_version_matches_installed(app):
+    """The FastAPI app's OpenAPI-reported version is the runtime surface users hit at /openapi.json."""
+    assert app.version == __version__
+
+
+@pytest.mark.asyncio
+async def test_health_endpoint_reports_installed_version(client):
+    """/api/health returns version=__version__ — the endpoint most-often scraped by monitors."""
+    response = await client.get("/api/health")
+    body = response.json()
+    assert body["version"] == __version__
+
+
+def test_diagnose_read_version_matches_installed():
+    """The diagnose bundle's manifest reports the real version, not 'unknown'."""
+    from memory_vault.diagnose import _read_version
+
+    assert _read_version() == __version__


### PR DESCRIPTION
## Summary

Prepares the v1.0.9 release. Ships #118's pool-checkout fix (from @hmodes) and closes #97 by aligning every version surface and fixing the root cause of the `diagnose` `unknown` report.

## What changed

**Version bump — the primary bump.**
- `pyproject.toml`: `1.0.8` → `1.0.9`

**Descriptor sweep — the drifting surfaces flagged in #97.**
- `docker-compose.yml`: app image tag `1.0.6` → `1.0.9`
- `server.json`: `version` and MCP image identifier tag both `1.0.6` → `1.0.9`
- `src/memory_vault/api/app.py`: FastAPI `version="0.4.0"` → `version=__version__` (imported from `memory_vault`)
- `src/memory_vault/api/routers/health.py`: `/api/health` response `version="0.4.0"` → `version=__version__`

**Root-cause fix — so drift can't recur silently in future releases.**
- `src/memory_vault/__init__.py`: new module-level `__version__` resolved via `importlib.metadata.version("memory-vault")` with `PackageNotFoundError` fallback to `"unknown"`. Single source of truth for every runtime surface.
- `src/memory_vault/diagnose.py`: `_read_version()` no longer walks the source tree for `pyproject.toml` (which doesn't exist in the wheel — the src-layout ships `memory_vault/`, not `pyproject.toml` — so the old lookup returned `"unknown"` on every pip-installed deployment). Now delegates to `memory_vault.__version__`.

**Release-guard extension — so CI blocks a tag whose descriptors drift.**
- `.github/workflows/release.yml`: the `version-guard` job now asserts that `pyproject.toml`, `docker-compose.yml` app image tag, `server.json` version, **and** `server.json` MCP image identifier tag all match the tag being released. Fails with a per-surface error message before docker/release jobs run.

**Test coverage — 8 new tests, all agreement checks.**
- `tests/test_version_reporting.py`:
  - `__version__` is a real semver string (not `"unknown"`)
  - `pyproject.toml` version matches installed
  - `docker-compose.yml` app image tag matches installed
  - `server.json` version matches installed
  - `server.json` MCP image identifier tag matches installed
  - FastAPI `create_app().version` matches installed
  - `/api/health` response `version` matches installed
  - `diagnose._read_version()` matches installed

## Test plan

- [x] Full suite passes on Python 3.11 against pgvector: **179 passed, 0 failed** (171 pre-existing + 8 new)
- [x] `__version__` resolves via `importlib.metadata` (verified `1.0.9` after `pip install -e .`)
- [x] Every version surface reports `1.0.9` on the new branch
- [ ] CI green (matrix 3.11 + 3.13)
- [ ] After merge: annotate + push tag `v1.0.9`, release workflow runs the extended version-guard and publishes the release

## Closes

- Closes #97 — version drift across active release/runtime descriptors
