### PR TITLE
fix(search): reject unknown space names instead of silently widening

### DIFF
--- a/src/memory_vault/api/routers/chat.py
+++ b/src/memory_vault/api/routers/chat.py
@@ -229,7 +229,7 @@ async def _retrieve_context(
     space_ids = await resolve_space_names(req.spaces) if req.spaces else None
     results, _variations, query_ms = await hybrid_search(
         query_text=req.question,
-        space_ids=space_ids or None,
+        space_ids=space_ids,
         limit=req.limit,
     )
     history, results = _apply_token_budget(req.question, req.history, results)

--- a/src/memory_vault/api/routers/search.py
+++ b/src/memory_vault/api/routers/search.py
@@ -30,7 +30,7 @@ async def search(req: SearchRequest) -> SearchResponse:
 
     results, variations, elapsed_ms = await hybrid_search(
         query_text=req.query,
-        space_ids=space_ids or None,
+        space_ids=space_ids,
         since=since_dt,
         limit=req.limit,
     )

--- a/src/memory_vault/cli.py
+++ b/src/memory_vault/cli.py
@@ -172,7 +172,7 @@ async def _cmd_search(query: str, space: str | None, limit: int) -> None:
     space_ids = await resolve_space_names([space] if space else None)
     results, variations, elapsed_ms = await hybrid_search(
         query,
-        space_ids=space_ids or None,
+        space_ids=space_ids if space else None,
         limit=limit,
     )
 

--- a/src/memory_vault/mcp/server.py
+++ b/src/memory_vault/mcp/server.py
@@ -191,7 +191,7 @@ async def recall(
 
         results, variations, elapsed_ms = await hybrid_search(
             query_text=query,
-            space_ids=space_ids or None,
+            space_ids=space_ids,
             since=since_dt,
             limit=limit,
         )

--- a/src/memory_vault/models/db.py
+++ b/src/memory_vault/models/db.py
@@ -102,6 +102,26 @@ async def fetch_all(
         return await cur.fetchall()  # type: ignore[return-value]
 
 
+async def has_column(table: str, column: str) -> bool:
+    """
+    Whether `column` exists on `table` in the connected database.
+
+    Used to detect whether a not-yet-applied migration's columns are available, so
+    callers can degrade gracefully (an interim compatibility proxy, or a clear
+    "unavailable until migration" message) instead of erroring or half-writing
+    against a database that's behind the code. No caching: called rarely (once per
+    recall/mutation call, not in a hot loop), and a schema change applied while the
+    server is running should be picked up on the very next call, not require a
+    restart to notice.
+    """
+    row = await fetch_one(
+        """SELECT 1 FROM information_schema.columns
+           WHERE table_name = %s AND column_name = %s""",
+        (table, column),
+    )
+    return row is not None
+
+
 async def health_check() -> dict[str, Any]:
     """Run a lightweight check and return pool + server status."""
     pool = await get_pool()

--- a/src/memory_vault/services/search.py
+++ b/src/memory_vault/services/search.py
@@ -254,14 +254,24 @@ def _build_where_clause(
     space_ids: list[int] | None,
     since: datetime | None,
 ) -> tuple[list[str], list[Any]]:
-    """Build shared WHERE clauses for both search arms."""
+    """Build shared WHERE clauses for both search arms.
+
+    space_ids semantics:
+      None → no space filter (search every space)
+      []   → caller asked for specific spaces but none resolved; return zero rows
+             (a hard `false` predicate) rather than silently widening to every space
+      [ids...] → filter to those space IDs
+    """
     where_clauses: list[str] = ["(c.metadata->>'forgotten')::boolean IS NOT TRUE"]
     params: list[Any] = []
 
-    if space_ids:
-        placeholders = ", ".join(["%s"] * len(space_ids))
-        where_clauses.append(f"c.space_id IN ({placeholders})")
-        params.extend(space_ids)
+    if space_ids is not None:
+        if space_ids:
+            placeholders = ", ".join(["%s"] * len(space_ids))
+            where_clauses.append(f"c.space_id IN ({placeholders})")
+            params.extend(space_ids)
+        else:
+            where_clauses.append("false")
 
     if since:
         where_clauses.append("c.created_at >= %s")

--- a/tests/test_space_filter_security.py
+++ b/tests/test_space_filter_security.py
@@ -1,0 +1,141 @@
+"""
+Regression + security tests for the space-filter behavior in _build_where_clause,
+plus unit coverage for has_column().
+
+Background: recall(spaces=["unknown"]) used to silently widen to every space —
+resolve_space_names() returns [] for unknown names, and every hybrid_search
+caller collapsed that back to None via `or None`, so the filter disappeared and
+the query hit every space in the vault. Fix: propagate [] all the way through
+_build_where_clause, which now emits a hard `false` predicate for that case.
+
+Integration: shares the memory_vault_test database from conftest.py.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# has_column()
+# ---------------------------------------------------------------------------
+
+
+class TestHasColumn:
+    @pytest.mark.asyncio
+    async def test_true_for_a_column_that_exists(self):
+        from memory_vault.models.db import has_column
+
+        assert await has_column("chunks", "content") is True
+
+    @pytest.mark.asyncio
+    async def test_false_for_a_column_that_does_not_exist(self):
+        from memory_vault.models.db import has_column
+
+        assert await has_column("chunks", "definitely_not_a_real_column_xyz") is False
+
+    @pytest.mark.asyncio
+    async def test_false_for_a_table_that_does_not_exist(self):
+        from memory_vault.models.db import has_column
+
+        assert await has_column("no_such_table_xyz", "id") is False
+
+
+# ---------------------------------------------------------------------------
+# _build_where_clause — space_ids semantics
+# ---------------------------------------------------------------------------
+
+
+class TestBuildWhereClause:
+    def test_none_means_no_space_filter(self):
+        from memory_vault.services.search import _build_where_clause
+
+        clauses, params = _build_where_clause(None, None)
+        assert not any("space_id" in c for c in clauses)
+        assert not any(c == "false" for c in clauses)
+        assert params == []
+
+    def test_empty_list_emits_hard_false_predicate(self):
+        """The security regression guard: caller asked for specific spaces but
+        none resolved — must return zero rows, not silently widen to all spaces."""
+        from memory_vault.services.search import _build_where_clause
+
+        clauses, params = _build_where_clause([], None)
+        assert "false" in clauses
+        assert not any("space_id" in c for c in clauses)
+        assert params == []
+
+    def test_populated_list_filters_to_those_ids(self):
+        from memory_vault.services.search import _build_where_clause
+
+        clauses, params = _build_where_clause([1, 2, 3], None)
+        assert any("c.space_id IN" in c for c in clauses)
+        assert params == [1, 2, 3]
+        assert not any(c == "false" for c in clauses)
+
+    def test_forgotten_check_is_always_present(self):
+        from memory_vault.services.search import _build_where_clause
+
+        for space_ids in (None, [], [1]):
+            clauses, _ = _build_where_clause(space_ids, None)
+            assert "(c.metadata->>'forgotten')::boolean IS NOT TRUE" in clauses
+
+
+# ---------------------------------------------------------------------------
+# End-to-end via REST /api/search: unknown space name returns zero results
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestSearchUnknownSpaceReturnsEmpty:
+    async def test_search_with_unknown_space_returns_no_hits(self, client, auth_headers):
+        """The full security regression through /api/search: a spaces=["unknown"]
+        filter used to silently widen to every space because resolve_space_names
+        returned [] and the caller collapsed it to None via `or None`. Now it
+        must return zero hits."""
+        r = await client.post(
+            "/api/ingest/text",
+            headers=auth_headers,
+            json={
+                "text": "spacefilter_unique_token_ALPHA content in default space",
+                "space": "default",
+            },
+        )
+        assert r.status_code == 200
+
+        r = await client.post(
+            "/api/search",
+            headers=auth_headers,
+            json={
+                "query": "spacefilter_unique_token_ALPHA",
+                "spaces": ["nonexistent_space_xyz"],
+            },
+        )
+        assert r.status_code == 200
+        body = r.json()
+        assert body["total_results"] == 0, (
+            "unknown space name must not widen to every space — "
+            f"got {body['total_results']} results"
+        )
+
+    async def test_search_with_no_space_filter_still_finds_content(
+        self, client, auth_headers
+    ):
+        """Regression guard: fix must not break the no-filter path — omitting
+        `spaces` (None) still searches every space as before."""
+        r = await client.post(
+            "/api/ingest/text",
+            headers=auth_headers,
+            json={
+                "text": "spacefilter_unique_token_BETA content in default space",
+                "space": "default",
+            },
+        )
+        assert r.status_code == 200
+
+        r = await client.post(
+            "/api/search",
+            headers=auth_headers,
+            json={"query": "spacefilter_unique_token_BETA"},
+        )
+        assert r.status_code == 200
+        assert r.json()["total_results"] >= 1

--- a/tests/test_space_filter_security.py
+++ b/tests/test_space_filter_security.py
@@ -117,9 +117,7 @@ class TestSearchUnknownSpaceReturnsEmpty:
             f"got {body['total_results']} results"
         )
 
-    async def test_search_with_no_space_filter_still_finds_content(
-        self, client, auth_headers
-    ):
+    async def test_search_with_no_space_filter_still_finds_content(self, client, auth_headers):
         """Regression guard: fix must not break the no-filter path — omitting
         `spaces` (None) still searches every space as before."""
         r = await client.post(


### PR DESCRIPTION
## Summary

Fixes a silent space-filter widening bug: `recall(spaces=["unknown_name"])` used to return results from every space, not zero.

Root cause: `resolve_space_names()` returns `[]` for unknown names, and every `hybrid_search` caller collapsed `[]` back to `None` via `space_ids or None`, so the filter dropped out and the query hit every space in the vault.

Fix propagates `[]` all the way through `_build_where_clause`, which now emits a hard `false` predicate for the empty-list case. `or None` is removed at all four `hybrid_search` call sites (MCP, CLI, REST search, REST chat) so `[]` can reach the fix.

Also adds `has_column()` to `models/db.py` as defensive infrastructure for future migrations — no callers today, but the helper is small, self-contained, and useful for graceful degradation against not-yet-applied migrations.

## What's in this PR

- `_build_where_clause` — `space_ids=[]` now emits `false` instead of dropping the filter
- Four caller updates — `or None` removed so `[]` propagates
- `has_column(table, column)` — schema introspection helper
- 9 new tests: 3 unit for `has_column`, 4 unit for `_build_where_clause` semantics, 2 end-to-end via `/api/search`

## What's not in this PR

Cherry-picked from PR #52 (@gatesl). The load-bearing security fix and defensive helper travel here; the space-lifecycle features from PR #52 (`_ensure_space` auto-create, `move_memory`, `supersede_memory`, `migrate_tags`, migration 004) are not included and will land as separate work.

## Test plan

- [x] `pytest -q` — 188 pass (179 baseline + 9 new), zero regressions
- [x] `ruff check` — clean
- [x] End-to-end verified through `/api/search` with an unknown space name → 0 results
- [x] End-to-end verified through `/api/search` with no space filter → still finds content (no-filter path unaffected)

Closes #52.

Co-Authored-By: Lee Gates <gatesl@gmail.com>
