### PR TITLE
fix(db): reject startup when EMBEDDING_DIMENSIONS mismatches schema

### DIFF
--- a/src/memory_vault/models/db.py
+++ b/src/memory_vault/models/db.py
@@ -40,7 +40,42 @@ async def init_pool(min_size: int = 2, max_size: int = 10) -> AsyncConnectionPoo
     )
     await _pool.open()
     logger.info("Connection pool opened (min=%d, max=%d)", min_size, max_size)
+
+    await _verify_embedding_dimension()
+
     return _pool
+
+
+async def _verify_embedding_dimension() -> None:
+    """Fail fast if EMBEDDING_DIMENSIONS does not match the schema.
+
+    The `chunks.embedding` column type is `vector(N)`; N is fixed at CREATE
+    TABLE. If `settings.embedding_dimensions` diverges, every INSERT/SELECT of
+    an embedding blows up mid-request. Cheaper for the process to refuse to
+    start than to accept traffic and error on the first embedding.
+
+    Skips silently before migration 001 has ever run (fresh install) — the
+    check has nothing to compare against yet, and run_migrations() is the
+    next natural step in that flow.
+    """
+    schema_dim = await fetch_one(
+        """SELECT a.atttypmod AS dim
+           FROM pg_attribute a
+           JOIN pg_class c ON c.oid = a.attrelid
+           WHERE c.relname = 'chunks' AND a.attname = 'embedding'"""
+    )
+    if schema_dim is None:
+        return  # Pre-migration; nothing to verify yet.
+
+    configured = settings.embedding_dimensions
+    actual = int(schema_dim["dim"])
+    if configured != actual:
+        raise RuntimeError(
+            f"EMBEDDING_DIMENSIONS={configured} does not match the "
+            f"chunks.embedding vector({actual}) column in the connected "
+            f"database. Set EMBEDDING_DIMENSIONS={actual} or point at a "
+            f"database whose schema matches your configured dimension."
+        )
 
 
 async def get_pool() -> AsyncConnectionPool:

--- a/tests/test_embedding_dimension_guard.py
+++ b/tests/test_embedding_dimension_guard.py
@@ -1,0 +1,82 @@
+"""
+Regression tests for the startup guard that refuses to open a pool when
+`EMBEDDING_DIMENSIONS` does not match the connected DB's `chunks.embedding`
+vector dimension.
+
+Background: MV exposes EMBEDDING_DIMENSIONS as configuration, but the
+initial schema hardcodes `vector(384)`. Any other setting silently succeeds
+until the first embedding INSERT/SELECT, which then fails opaquely.
+
+The guard queries pg_attribute for the actual `vector(N)` column dimension
+and compares it to `settings.embedding_dimensions` at pool-open time,
+raising RuntimeError with a clear message on mismatch.
+
+Integration: shares the memory_vault_test database from conftest.py — it's
+already migrated with vector(384) by the session-scoped fixture, so we test
+mismatch by monkeypatching settings, not by mutating the schema.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+pytestmark = pytest.mark.asyncio
+
+
+def _settings_with(monkeypatch, **overrides):
+    """Swap `db.settings` for a copy with the given field overrides.
+
+    Settings is a frozen dataclass, so per-attribute monkeypatch doesn't work;
+    dataclasses.replace() gives us a new frozen instance with the overrides.
+    """
+    from memory_vault.models import db
+
+    monkeypatch.setattr(db, "settings", replace(db.settings, **overrides))
+
+
+class TestVerifyEmbeddingDimension:
+    async def test_passes_silently_when_config_matches_schema(self):
+        """Default flow: EMBEDDING_DIMENSIONS=384 matches vector(384) schema."""
+        from memory_vault.models.db import _verify_embedding_dimension
+
+        # No override — actual settings.embedding_dimensions is 384 by
+        # default and the test DB has vector(384). Should not raise.
+        await _verify_embedding_dimension()
+
+    async def test_raises_when_config_does_not_match_schema(self, monkeypatch):
+        """The regression guard: mismatched config must fail fast with a
+        clear error naming both the configured and actual dimensions."""
+        from memory_vault.models import db
+
+        _settings_with(monkeypatch, embedding_dimensions=768)
+        with pytest.raises(RuntimeError, match=r"EMBEDDING_DIMENSIONS=768.*vector\(384\)"):
+            await db._verify_embedding_dimension()
+
+    async def test_error_message_names_both_dimensions(self, monkeypatch):
+        """Failure message must give operators both numbers so the fix is
+        obvious (either bump config or point at a matching DB)."""
+        from memory_vault.models import db
+
+        _settings_with(monkeypatch, embedding_dimensions=1024)
+        with pytest.raises(RuntimeError) as exc:
+            await db._verify_embedding_dimension()
+        msg = str(exc.value)
+        assert "1024" in msg
+        assert "384" in msg
+        assert "EMBEDDING_DIMENSIONS" in msg
+
+    async def test_skips_gracefully_when_chunks_table_missing(self, monkeypatch):
+        """Fresh install path: before migration 001 has ever run, the chunks
+        table does not exist yet. The guard must skip cleanly rather than
+        crash — run_migrations() is the natural next step in that flow."""
+        from memory_vault.models import db
+
+        async def _no_row(*_args, **_kwargs):
+            return None
+
+        monkeypatch.setattr(db, "fetch_one", _no_row)
+        _settings_with(monkeypatch, embedding_dimensions=999)
+        # Must not raise, even with a mismatched configured dimension.
+        await db._verify_embedding_dimension()


### PR DESCRIPTION
## Summary

Fixes #114: `EMBEDDING_DIMENSIONS` was exposed as configuration but the initial schema hardcodes `chunks.embedding` as `vector(384)`. Any other setting succeeded at config load and failed opaquely on the first embedding INSERT/SELECT.

Fix: after `init_pool()` opens the connection, query `pg_attribute` for the actual `vector(N)` dimension on `chunks.embedding` and compare to `settings.embedding_dimensions`. On mismatch, raise `RuntimeError` with a clear message naming both dimensions so the operator knows to either bump the env var or point at a matching DB.

## Design notes

- **Schema-aware, not hardcoded.** The check compares config against the actual `vector(N)` column dimension, not a hardcoded 384. A future migration to a different dimension just works, as long as the operator's config matches.
- **Fresh install path.** Before migration 001 has run, `chunks` doesn't exist yet; the guard skips silently and lets `run_migrations()` proceed.
- **Fail-fast, not fail-later.** Refusing to start beats accepting traffic and erroring on the first embedding.

## Error message shape

```
EMBEDDING_DIMENSIONS=768 does not match the chunks.embedding vector(384)
column in the connected database. Set EMBEDDING_DIMENSIONS=384 or point
at a database whose schema matches your configured dimension.
```

## Test plan

- [x] `pytest -q` — 192 pass (188 baseline + 4 new), zero regressions
- [x] `ruff check` — clean
- [x] `ruff format --check` — clean
- [x] Guard tested: match (silent), mismatch (raises with both dimensions in message), missing chunks table (skips cleanly)

Closes #114.
