### PR TITLE
chore(release): auto-publish server.json to MCP Registry on tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,6 +107,35 @@ jobs:
           cache-from: type=gha,scope=${{ matrix.image }}
           cache-to: type=gha,mode=max,scope=${{ matrix.image }}
 
+  publish-mcp-registry:
+    name: Publish server.json to MCP Registry
+    runs-on: ubuntu-latest
+    needs: docker
+    # OIDC identifies the workflow as belonging to the MihaiBuilds org, which
+    # is what grants publish rights to the io.github.MihaiBuilds/* namespace.
+    # No stored secret required.
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install mcp-publisher
+        run: |
+          # Always pull the latest release — the registry is in preview and
+          # the CLI is versioned alongside the API. Pinning risks an
+          # "invalid audience" mismatch after a server-side change.
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" \
+            | tar xz mcp-publisher
+
+      - name: Authenticate to MCP Registry via GitHub OIDC
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish server.json
+        # version-guard has already asserted server.json.version matches the
+        # git tag, so no in-workflow rewrite is needed here.
+        run: ./mcp-publisher publish
+
   release:
     name: Create GitHub Release
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Adds a `publish-mcp-registry` job to the release workflow that pushes the checked-in `server.json` to `registry.modelcontextprotocol.io` on every `v*.*.*` tag. Without this, the registry listing drifts from the docker image + GitHub Release with every version bump.

## Authentication

Uses **GitHub OIDC** (`permissions: id-token: write, contents: read`). Publish access to the `io.github.MihaiBuilds/*` namespace is granted based on the workflow's org context — no stored secret required.

Follows the [official MCP Registry GitHub Actions guide](https://github.com/modelcontextprotocol/registry/blob/main/docs/modelcontextprotocol-io/github-actions.mdx).

## Workflow slot order

```
version-guard → docker → publish-mcp-registry → release
```

- After `docker` so the ghcr.io image `server.json` references exists first.
- Before `release` so the GitHub Release still creates as a visible surface even if MCP publish fails.

## No in-workflow version rewrite

`version-guard` already asserts `server.json.version` matches the git tag, so the checkout's `server.json` is already at the right version by the time this job runs. No `jq`-in-place mutation needed.

## Test plan

The workflow only runs on `v*.*.*` tag push, so this PR itself doesn't exercise it. First real test is the next tag (v1.0.10).

- [x] YAML parses (verified via `yaml.safe_load`)
- [x] Job structure matches the official OIDC example verbatim
- [ ] Real publish verified on next tag push

If OIDC turns out not to grant org-namespace publish on first run, fallback is a PAT-based Environment secret with `read:org` scope — one-line workflow swap.
