### PR TITLE
fix(deps): pin mcp<2.0.0 + add MCP server import smoke test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,11 @@ dependencies = [
     "sentence-transformers>=5.5.0,<6",
     "numpy>=2.4.6",
     "python-dotenv>=1.2.2",
-    "mcp>=1.28.1",
+    # Pinned <2.0.0 — mcp 2.0.0 (released 2026-07-28) removed mcp.server.fastmcp
+    # which server.py imports. 1.29.0 is the final maintained 1.x release cut
+    # on the same day for exactly this scenario. Migration to the 2.0.0 API
+    # shape is planned for v1.1.
+    "mcp>=1.28.1,<2.0.0",
     "fastapi>=0.136.1,<1",
     "uvicorn[standard]>=0.51.0,<1",
     "python-multipart>=0.0.29",

--- a/tests/test_mcp_server_import.py
+++ b/tests/test_mcp_server_import.py
@@ -1,0 +1,37 @@
+"""
+CI smoke test — proves memory_vault.mcp.server imports cleanly.
+
+Historically no test in this suite imported the MCP server module, so a
+transitive dep drift (mcp 2.0.0 removing mcp.server.fastmcp on 2026-07-28)
+silently shipped as v1.0.9 and left the MCP-only docker image dead on
+arrival for six days before anyone noticed. See issue #126.
+
+This test is intentionally minimal: it exists so any regression that breaks
+the MCP server's import fails CI immediately, whether it comes from an
+upstream mcp release, a local edit, or a pyproject drift. Any test that
+imports memory_vault.mcp.server would serve this purpose; a dedicated
+smoke test makes the intent explicit and keeps the failure message
+obvious ("MCP server module failed to import") when it triggers.
+"""
+
+from __future__ import annotations
+
+
+def test_mcp_server_module_imports_cleanly():
+    """Import the MCP server module. Any ImportError here blocks the release."""
+    import memory_vault.mcp.server as mcp_server
+
+    # Confirm the FastMCP instance was constructed at module load. If mcp.server.fastmcp
+    # is missing (mcp 2.0.0+) the import above already raised — this line is defensive
+    # against a future refactor that turns FastMCP into a lazy factory.
+    assert mcp_server.mcp is not None
+
+
+def test_mcp_server_tools_are_registered():
+    """The four canonical tools must be present on the server module."""
+    import memory_vault.mcp.server as mcp_server
+
+    for tool_name in ("recall", "remember", "forget", "memory_status"):
+        assert hasattr(mcp_server, tool_name), (
+            f"MCP tool `{tool_name}` is not exported from memory_vault.mcp.server"
+        )


### PR DESCRIPTION
## Summary

Fixes #126: the `ghcr.io/mihaibuilds/memory-vault-mcp:1.0.9` image crashes at startup with `ModuleNotFoundError: No module named 'mcp.server.fastmcp'`. Fresh `pip install -e .` from source hits the same crash.

Root cause: `pyproject.toml` specified `mcp>=1.28.1` unpinned. `mcp` 2.0.0 (released 2026-07-28) removed the `mcp.server.fastmcp` module that `src/memory_vault/mcp/server.py:39` imports. Any install after that date resolves to 2.0.0 and blows up.

## What's in this PR

- **Pin `mcp>=1.28.1,<2.0.0`** in `pyproject.toml` — resolves to mcp 1.29.0, the final maintained 1.x release cut on the same day as 2.0.0 for exactly this scenario
- **New smoke test** `tests/test_mcp_server_import.py` — imports `memory_vault.mcp.server` and asserts the FastMCP instance + the four canonical tools (`recall`, `remember`, `forget`, `memory_status`) exist. Two lines of test that would have failed CI on v1.0.9 and blocked the bad release

## Why the pin isn't a workaround

mcp 1.29.0 was cut on the same day (2026-07-28) as 2.0.0 specifically as the supported endpoint for callers who need time to migrate. It's a maintained release, not a stale one. Migration to the mcp 2.0.0 API shape is planned for v1.1.

## Impact and blast radius

Detailed in #126. Short version:
- v1.0.9 MCP image: broken for fresh pulls since 2026-08-02
- v1.0.7 / v1.0.8 images: still work (mcp 1.28.x baked in at build time)
- Fresh source installs: broken today
- Fix rolls out in v1.0.10

## Test plan

- [x] `pytest -q` — 204 pass (202 baseline + 2 new smoke tests), zero regressions
- [x] `ruff check` — clean
- [x] `ruff format --check` — clean
- [x] Verified locally: reinstalled MV in the venv, mcp resolves to 1.29.0, `from mcp.server.fastmcp import FastMCP` succeeds, MCP server module imports and constructs the FastMCP instance
- [x] Smoke test proven to catch the class of failure: without the pin, the smoke test import fails immediately

## Follow-up

- Migration to the mcp 2.0.0 API shape lands in v1.1.
- The smoke test only imports today; extending it to verify each `@mcp.tool()` is discoverable via the MCP protocol is a plausible future addition, not scoped for this PR.

Closes #126.
