### PR TITLE
fix(graph): exclude forgotten chunks from every /api/graph/* surface

### DIFF
--- a/src/memory_vault/api/routers/graph.py
+++ b/src/memory_vault/api/routers/graph.py
@@ -53,15 +53,19 @@ async def list_entities(
     # templates ("ms.name = %s", "e.type = %s"). User values go through %s
     # parameters in `params`. No user-controlled SQL fragments.
     # Subquery builds entity + mention_count, then filters by min_mentions.
+    # Mentions on forgotten chunks are excluded so mention_count reflects only
+    # live mentions and entities with zero live mentions drop out via HAVING.
     base_sql = f"""
         SELECT e.id, e.name, e.type, ms.name AS space_name, e.created_at,
-               COUNT(em.id) AS mention_count
+               COUNT(c.id) AS mention_count
         FROM entities e
         JOIN memory_spaces ms ON ms.id = e.space_id
         LEFT JOIN entity_mentions em ON em.entity_id = e.id
+        LEFT JOIN chunks c ON c.id = em.chunk_id
+            AND (c.metadata->>'forgotten')::boolean IS NOT TRUE
         WHERE {where_sql}
         GROUP BY e.id, ms.name
-        HAVING COUNT(em.id) >= %s
+        HAVING COUNT(c.id) >= %s
     """  # nosec B608
 
     count_sql = f"SELECT COUNT(*) AS total FROM ({base_sql}) sub"  # nosec B608
@@ -94,9 +98,14 @@ async def list_entities(
 
 @router.get("/entities/{entity_id}", response_model=EntityDetail)
 async def get_entity(entity_id: str) -> EntityDetail:
+    # mention_count reflects only mentions on live (non-forgotten) chunks.
     entity = await fetch_one(
         """SELECT e.id, e.name, e.type, ms.name AS space_name, e.created_at,
-                  (SELECT COUNT(*) FROM entity_mentions em WHERE em.entity_id = e.id)
+                  (SELECT COUNT(*)
+                     FROM entity_mentions em
+                     JOIN chunks c ON c.id = em.chunk_id
+                    WHERE em.entity_id = e.id
+                      AND (c.metadata->>'forgotten')::boolean IS NOT TRUE)
                       AS mention_count
            FROM entities e
            JOIN memory_spaces ms ON ms.id = e.space_id
@@ -109,18 +118,22 @@ async def get_entity(entity_id: str) -> EntityDetail:
             detail=f"Entity not found: {entity_id}",
         )
 
-    # All mentions with a short chunk preview, newest first.
+    # All live mentions with a short chunk preview, newest first. Forgotten
+    # chunks are excluded so their preview text never surfaces here.
     mention_rows = await fetch_all(
         """SELECT em.chunk_id, em.start_offset, em.end_offset,
                   LEFT(c.content, %s) AS chunk_preview
            FROM entity_mentions em
            JOIN chunks c ON c.id = em.chunk_id
            WHERE em.entity_id = %s
+             AND (c.metadata->>'forgotten')::boolean IS NOT TRUE
            ORDER BY em.created_at DESC""",
         (CHUNK_PREVIEW_LEN, entity_id),
     )
 
-    # Related entities via relationships (both directions), aggregated.
+    # Related entities via relationships (both directions), aggregated. A
+    # relationship backed by a forgotten chunk drops out; a relationship with
+    # no backing chunk (chunk_id IS NULL, from future manual/LLM tagging) stays.
     related_rows = await fetch_all(
         """SELECT other.id, other.name, other.type, COUNT(*) AS co_mention_count
            FROM relationships r
@@ -128,7 +141,12 @@ async def get_entity(entity_id: str) -> EntityDetail:
                WHEN r.source_entity_id = %s THEN r.target_entity_id
                ELSE r.source_entity_id
            END
-           WHERE r.source_entity_id = %s OR r.target_entity_id = %s
+           WHERE (r.source_entity_id = %s OR r.target_entity_id = %s)
+             AND NOT EXISTS (
+                 SELECT 1 FROM chunks c
+                 WHERE c.id = r.chunk_id
+                   AND (c.metadata->>'forgotten')::boolean IS TRUE
+             )
            GROUP BY other.id, other.name, other.type
            ORDER BY co_mention_count DESC, other.name ASC""",
         (entity_id, entity_id, entity_id),
@@ -175,7 +193,16 @@ async def list_relationships(
     limit: int = Query(default=50, ge=1, le=500),
     offset: int = Query(default=0, ge=0),
 ) -> RelationshipList:
-    where: list[str] = []
+    # Always exclude relationships backed by forgotten chunks; relationships
+    # with chunk_id IS NULL (future manual/LLM-tagged) have no backing chunk
+    # and stay visible.
+    where: list[str] = [
+        "NOT EXISTS ("
+        "SELECT 1 FROM chunks c "
+        "WHERE c.id = r.chunk_id "
+        "AND (c.metadata->>'forgotten')::boolean IS TRUE"
+        ")"
+    ]
     params: list = []
 
     if entity_id is not None:
@@ -191,7 +218,7 @@ async def list_relationships(
         )
         params.append(space)
 
-    where_sql = " AND ".join(where) if where else "TRUE"
+    where_sql = " AND ".join(where)
 
     # nosec B608 — `where_sql` is composed from a closed set of literal
     # templates; user values are bound via %s parameters.
@@ -258,30 +285,37 @@ async def visualize(
     # nosec B608 — `where_sql` composed from closed-set literal templates;
     # user values bound via %s parameters.
     # Nodes: pick top `max_nodes` by mention_count, filtered by min_mentions.
+    # Mentions on forgotten chunks are excluded via the LEFT JOIN predicate,
+    # so mention_count reflects only live mentions and nodes with zero live
+    # mentions drop out via HAVING.
     node_rows = await fetch_all(
-        f"""SELECT e.id, e.name, e.type, COUNT(em.id) AS mention_count
+        f"""SELECT e.id, e.name, e.type, COUNT(c.id) AS mention_count
             FROM entities e
             JOIN memory_spaces ms ON ms.id = e.space_id
             LEFT JOIN entity_mentions em ON em.entity_id = e.id
+            LEFT JOIN chunks c ON c.id = em.chunk_id
+                AND (c.metadata->>'forgotten')::boolean IS NOT TRUE
             WHERE {where_sql}
             GROUP BY e.id
-            HAVING COUNT(em.id) >= %s
+            HAVING COUNT(c.id) >= %s
             ORDER BY mention_count DESC, e.name ASC
             LIMIT %s""",  # nosec B608
         tuple(params + [min_mentions, max_nodes]),
     )
 
     # Count what would have been returned without the cap, so the frontend
-    # can indicate truncation.
+    # can indicate truncation. Same live-mention filter as the node query.
     total_row = await fetch_one(
         f"""SELECT COUNT(*) AS total FROM (
                 SELECT e.id
                 FROM entities e
                 JOIN memory_spaces ms ON ms.id = e.space_id
                 LEFT JOIN entity_mentions em ON em.entity_id = e.id
+                LEFT JOIN chunks c ON c.id = em.chunk_id
+                    AND (c.metadata->>'forgotten')::boolean IS NOT TRUE
                 WHERE {where_sql}
                 GROUP BY e.id
-                HAVING COUNT(em.id) >= %s
+                HAVING COUNT(c.id) >= %s
             ) sub""",  # nosec B608
         tuple(params + [min_mentions]),
     )
@@ -298,15 +332,21 @@ async def visualize(
         for r in node_rows
     ]
 
-    # Edges: only those connecting two surviving nodes.
+    # Edges: only those connecting two surviving nodes AND backed by a live
+    # chunk (or unbacked — chunk_id IS NULL stays for future manual/LLM tags).
     edges: list[GraphEdge] = []
     if node_ids:
         edge_rows = await fetch_all(
             """SELECT source_entity_id, target_entity_id, type,
                       COUNT(*) AS weight
-               FROM relationships
+               FROM relationships r
                WHERE source_entity_id = ANY(%s::uuid[])
                  AND target_entity_id = ANY(%s::uuid[])
+                 AND NOT EXISTS (
+                     SELECT 1 FROM chunks c
+                     WHERE c.id = r.chunk_id
+                       AND (c.metadata->>'forgotten')::boolean IS TRUE
+                 )
                GROUP BY source_entity_id, target_entity_id, type
                ORDER BY weight DESC""",
             (node_ids, node_ids),

--- a/tests/test_graph_excludes_forgotten.py
+++ b/tests/test_graph_excludes_forgotten.py
@@ -1,0 +1,283 @@
+"""
+Regression tests for #109 — knowledge-graph endpoints must exclude data
+backed only by forgotten chunks.
+
+Background: DELETE /api/chunks/{id} sets chunks.metadata->>'forgotten' = true
+and drops the chunk from search. Before this fix, the four /api/graph/*
+endpoints did not apply the same predicate — entities, mentions, related
+entities, relationships, nodes, and edges all remained visible even after
+their sole backing chunk had been forgotten.
+
+Semantics locked (per issue design conversation):
+  * mention_count reports only live mentions (not raw entity_mention count)
+  * an entity with zero live mentions disappears from list_entities/visualize
+  * an entity detail still 404s only if the entity id is unknown; a live
+    entity with zero live mentions still returns detail with mention_count=0
+  * a relationship whose backing chunk is forgotten is hidden
+  * a relationship with chunk_id IS NULL (future manual/LLM tagging) is
+    treated as "not backed by any chunk" and stays visible
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from memory_vault.models.db import execute_query, fetch_one
+
+pytestmark = pytest.mark.asyncio
+
+
+# ---------------------------------------------------------------------------
+# Seed helpers (mirror the shape used by tests/test_graph_api.py)
+# ---------------------------------------------------------------------------
+
+
+async def _seed_space(name: str) -> int:
+    row = await fetch_one(
+        "INSERT INTO memory_spaces (name) VALUES (%s) "
+        "ON CONFLICT (name) DO UPDATE SET name = EXCLUDED.name RETURNING id",
+        (name,),
+    )
+    return row["id"]
+
+
+async def _seed_chunk(space_id: int, content: str = "seed content") -> str:
+    row = await fetch_one(
+        """INSERT INTO chunks (space_id, content, chunk_index)
+           VALUES (%s, %s, 0) RETURNING id""",
+        (space_id, content),
+    )
+    return str(row["id"])
+
+
+async def _seed_entity(space_id: int, name: str, ent_type: str = "Person") -> str:
+    row = await fetch_one(
+        """INSERT INTO entities (name, type, space_id)
+           VALUES (%s, %s, %s) RETURNING id""",
+        (name, ent_type, space_id),
+    )
+    return str(row["id"])
+
+
+async def _seed_mention(entity_id: str, chunk_id: str) -> None:
+    await execute_query(
+        """INSERT INTO entity_mentions
+               (entity_id, chunk_id, start_offset, end_offset)
+           VALUES (%s, %s, 0, 5)""",
+        (entity_id, chunk_id),
+    )
+
+
+async def _seed_relationship(
+    source_id: str, target_id: str, chunk_id: str | None, rel_type: str = "related_to"
+) -> None:
+    await execute_query(
+        """INSERT INTO relationships
+               (source_entity_id, target_entity_id, type, chunk_id)
+           VALUES (%s, %s, %s, %s)""",
+        (source_id, target_id, rel_type, chunk_id),
+    )
+
+
+async def _mark_forgotten(chunk_id: str) -> None:
+    """Set the same metadata.forgotten=true flag DELETE /api/chunks/{id} sets."""
+    await execute_query(
+        """UPDATE chunks
+              SET metadata = COALESCE(metadata, '{}'::jsonb)
+                             || jsonb_build_object('forgotten', true)
+            WHERE id = %s""",
+        (chunk_id,),
+    )
+
+
+# ---------------------------------------------------------------------------
+# /api/graph/entities
+# ---------------------------------------------------------------------------
+
+
+class TestListEntitiesExcludesForgotten:
+    async def test_entity_with_only_forgotten_mentions_drops_out(self, client, auth_headers):
+        space_id = await _seed_space("test-list-drop")
+        chunk_id = await _seed_chunk(space_id)
+        entity_id = await _seed_entity(space_id, "OnlyForgotten")
+        await _seed_mention(entity_id, chunk_id)
+
+        # Before forgetting: entity visible.
+        r = await client.get("/api/graph/entities?space=test-list-drop", headers=auth_headers)
+        names = [e["name"] for e in r.json()["entities"]]
+        assert "OnlyForgotten" in names
+
+        # After forgetting the sole backing chunk: entity drops out.
+        await _mark_forgotten(chunk_id)
+        r = await client.get("/api/graph/entities?space=test-list-drop", headers=auth_headers)
+        names = [e["name"] for e in r.json()["entities"]]
+        assert "OnlyForgotten" not in names
+
+    async def test_mention_count_reflects_only_live_mentions(self, client, auth_headers):
+        """The listed mention_count must count live mentions only, not raw
+        entity_mention rows. Semantics: user-visible counts stay consistent
+        with what they actually see."""
+        space_id = await _seed_space("test-list-count")
+        live_chunk = await _seed_chunk(space_id, "live")
+        forgotten_chunk = await _seed_chunk(space_id, "forgotten")
+        entity_id = await _seed_entity(space_id, "MixedMentions")
+        await _seed_mention(entity_id, live_chunk)
+        await _seed_mention(entity_id, forgotten_chunk)
+        await _mark_forgotten(forgotten_chunk)
+
+        r = await client.get("/api/graph/entities?space=test-list-count", headers=auth_headers)
+        row = next(e for e in r.json()["entities"] if e["name"] == "MixedMentions")
+        assert row["mention_count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# /api/graph/entities/{id}
+# ---------------------------------------------------------------------------
+
+
+class TestGetEntityExcludesForgotten:
+    async def test_forgotten_chunk_preview_never_surfaces(self, client, auth_headers):
+        """The reported leak: entity detail's mentions list must not include
+        chunk_preview text from a forgotten chunk."""
+        space_id = await _seed_space("test-detail-preview")
+        live_chunk = await _seed_chunk(space_id, "live preview text")
+        forgotten_chunk = await _seed_chunk(space_id, "secret forgotten preview text")
+        entity_id = await _seed_entity(space_id, "PreviewLeaker")
+        await _seed_mention(entity_id, live_chunk)
+        await _seed_mention(entity_id, forgotten_chunk)
+        await _mark_forgotten(forgotten_chunk)
+
+        r = await client.get(f"/api/graph/entities/{entity_id}", headers=auth_headers)
+        assert r.status_code == 200
+        previews = [m["chunk_preview"] for m in r.json()["mentions"]]
+        assert not any("secret forgotten" in p for p in previews)
+        assert any("live preview text" in p for p in previews)
+
+    async def test_detail_mention_count_matches_live_mentions_shown(self, client, auth_headers):
+        space_id = await _seed_space("test-detail-count")
+        live_a = await _seed_chunk(space_id, "a")
+        live_b = await _seed_chunk(space_id, "b")
+        forgotten_c = await _seed_chunk(space_id, "c")
+        entity_id = await _seed_entity(space_id, "CountConsistent")
+        await _seed_mention(entity_id, live_a)
+        await _seed_mention(entity_id, live_b)
+        await _seed_mention(entity_id, forgotten_c)
+        await _mark_forgotten(forgotten_c)
+
+        r = await client.get(f"/api/graph/entities/{entity_id}", headers=auth_headers)
+        body = r.json()
+        assert body["mention_count"] == 2
+        assert len(body["mentions"]) == 2
+
+    async def test_related_excludes_relationships_backed_by_forgotten_chunks(
+        self, client, auth_headers
+    ):
+        space_id = await _seed_space("test-detail-related")
+        live_chunk = await _seed_chunk(space_id, "live")
+        forgotten_chunk = await _seed_chunk(space_id, "forgotten")
+        alice = await _seed_entity(space_id, "AliceRel")
+        bob = await _seed_entity(space_id, "BobRel")
+        carol = await _seed_entity(space_id, "CarolRel")
+        # Alice → Bob backed by live chunk; Alice → Carol backed by forgotten chunk.
+        await _seed_relationship(alice, bob, live_chunk)
+        await _seed_relationship(alice, carol, forgotten_chunk)
+        await _mark_forgotten(forgotten_chunk)
+
+        r = await client.get(f"/api/graph/entities/{alice}", headers=auth_headers)
+        related_names = [x["name"] for x in r.json()["related"]]
+        assert "BobRel" in related_names
+        assert "CarolRel" not in related_names
+
+
+# ---------------------------------------------------------------------------
+# /api/graph/relationships
+# ---------------------------------------------------------------------------
+
+
+class TestListRelationshipsExcludesForgotten:
+    async def test_forgotten_backed_relationship_hidden(self, client, auth_headers):
+        space_id = await _seed_space("test-rel-hide")
+        live_chunk = await _seed_chunk(space_id, "live")
+        forgotten_chunk = await _seed_chunk(space_id, "forgotten")
+        a = await _seed_entity(space_id, "RelHideA")
+        b = await _seed_entity(space_id, "RelHideB")
+        c = await _seed_entity(space_id, "RelHideC")
+        await _seed_relationship(a, b, live_chunk, rel_type="live_edge")
+        await _seed_relationship(a, c, forgotten_chunk, rel_type="dead_edge")
+        await _mark_forgotten(forgotten_chunk)
+
+        r = await client.get(f"/api/graph/relationships?entity_id={a}", headers=auth_headers)
+        types = [x["type"] for x in r.json()["relationships"]]
+        assert "live_edge" in types
+        assert "dead_edge" not in types
+        assert r.json()["total"] == 1
+
+    async def test_relationship_with_null_chunk_id_stays_visible(self, client, auth_headers):
+        """chunk_id IS NULL means unbacked (future manual/LLM tags) — never
+        hidden by the forgotten filter."""
+        space_id = await _seed_space("test-rel-null")
+        a = await _seed_entity(space_id, "NullChunkA")
+        b = await _seed_entity(space_id, "NullChunkB")
+        await _seed_relationship(a, b, chunk_id=None, rel_type="manual_tag")
+
+        r = await client.get(f"/api/graph/relationships?entity_id={a}", headers=auth_headers)
+        types = [x["type"] for x in r.json()["relationships"]]
+        assert "manual_tag" in types
+
+
+# ---------------------------------------------------------------------------
+# /api/graph/visualize
+# ---------------------------------------------------------------------------
+
+
+class TestVisualizeExcludesForgotten:
+    async def test_node_with_only_forgotten_mentions_drops_out(self, client, auth_headers):
+        space_id = await _seed_space("test-viz-node")
+        forgotten_chunk = await _seed_chunk(space_id, "forgotten")
+        entity_id = await _seed_entity(space_id, "VizForgotten")
+        await _seed_mention(entity_id, forgotten_chunk)
+        await _mark_forgotten(forgotten_chunk)
+
+        r = await client.get("/api/graph/visualize?space=test-viz-node", headers=auth_headers)
+        names = [n["name"] for n in r.json()["nodes"]]
+        assert "VizForgotten" not in names
+
+    async def test_edge_backed_by_forgotten_chunk_hidden(self, client, auth_headers):
+        space_id = await _seed_space("test-viz-edge")
+        live_chunk = await _seed_chunk(space_id, "live")
+        forgotten_chunk = await _seed_chunk(space_id, "forgotten")
+        a = await _seed_entity(space_id, "VizEdgeA")
+        b = await _seed_entity(space_id, "VizEdgeB")
+        c = await _seed_entity(space_id, "VizEdgeC")
+        # Every node needs a live mention so it survives the node filter and
+        # can appear in the edge query.
+        await _seed_mention(a, live_chunk)
+        await _seed_mention(b, live_chunk)
+        await _seed_mention(c, live_chunk)
+        # A → B backed by live chunk (edge should survive)
+        # A → C backed by forgotten chunk (edge should drop)
+        await _seed_relationship(a, b, live_chunk, rel_type="live_ab")
+        await _seed_relationship(a, c, forgotten_chunk, rel_type="dead_ac")
+        await _mark_forgotten(forgotten_chunk)
+
+        r = await client.get("/api/graph/visualize?space=test-viz-edge", headers=auth_headers)
+        edge_types = [e["type"] for e in r.json()["edges"]]
+        assert "live_ab" in edge_types
+        assert "dead_ac" not in edge_types
+
+    async def test_truncation_count_uses_live_mentions_too(self, client, auth_headers):
+        """total_nodes_available (used for the truncation indicator) must count
+        only nodes with ≥1 live mention, matching what the node query returns."""
+        space_id = await _seed_space("test-viz-total")
+        live_chunk = await _seed_chunk(space_id, "live")
+        forgotten_chunk = await _seed_chunk(space_id, "forgotten")
+        live_ent = await _seed_entity(space_id, "VizLive")
+        dead_ent = await _seed_entity(space_id, "VizDead")
+        await _seed_mention(live_ent, live_chunk)
+        await _seed_mention(dead_ent, forgotten_chunk)
+        await _mark_forgotten(forgotten_chunk)
+
+        r = await client.get("/api/graph/visualize?space=test-viz-total", headers=auth_headers)
+        body = r.json()
+        assert body["node_count"] == 1
+        assert body["truncated"] is False


### PR DESCRIPTION
## Summary

Fixes #109: `DELETE /api/chunks/{id}` sets `chunks.metadata->>'forgotten' = true` and drops the chunk from search, but the four `/api/graph/*` endpoints did not apply the same predicate. Entities, mentions, related entities, relationships, nodes, and edges all remained visible even after the sole backing chunk had been forgotten. Chunk preview text from a forgotten chunk was also still readable via `/api/graph/entities/{id}`.

## What's in this PR

- **`list_entities`** — adds `LEFT JOIN chunks c ON c.id = em.chunk_id AND (c.metadata->>'forgotten')::boolean IS NOT TRUE`. `mention_count` is `COUNT(c.id)` (live mentions only). Entities with zero live mentions drop out via `HAVING`.
- **`get_entity`** — same shape in the `mention_count` subquery. Mentions listing adds the WHERE predicate directly (chunks already joined for preview text). Related entities filter relationships to only those whose backing chunk (if any) is not forgotten.
- **`list_relationships`** — filters via `NOT EXISTS (SELECT 1 FROM chunks WHERE id = r.chunk_id AND (c.metadata->>'forgotten')::boolean IS TRUE)`. Relationships with `chunk_id IS NULL` (future manual/LLM tagging) are preserved by the shape (a NULL chunk_id can't satisfy the exists check).
- **`visualize`** — same LEFT JOIN + HAVING shape as `list_entities` on both the node query and the truncation-counter query. Edge query gets the same `NOT EXISTS` filter as `list_relationships`.

## Semantics locked

- `mention_count` reports only live mentions, not raw `entity_mention` row count. Otherwise the number and the actual visible mentions would diverge, which is worse UX than the count being different from what an operator queries at the SQL layer.
- Entity with zero live mentions disappears from `list_entities` and `visualize` — same treatment as any other filter drop-out. Detail 404 stays reserved for unknown entity IDs; a live entity with zero live mentions still returns detail with `mention_count = 0`.
- Relationship with `chunk_id IS NULL` stays visible. Rationale: the schema comment on that column explicitly says "future manual/LLM tagging may not be tied to a specific chunk. Auto-extraction always populates it." A relationship not backed by any chunk cannot be "forgotten" because there's no chunk to forget.

## Perf

Verified via `EXPLAIN (ANALYZE, BUFFERS)` on a synthetic seed of 500 chunks (10% forgotten), 200 entities, 2000 mentions, 500 relationships:

| Query | Time | Plan |
|---|---|---|
| `list_entities` | 3.2 ms | Index-scan chain, chunks join is PK lookup |
| `visualize` (node query) | 3.3 ms | Same shape |
| `list_relationships` NOT EXISTS | 0.08 ms | Hash anti-join |

The `metadata->>'forgotten'` extraction runs per-row on the chunks side but chunks are PK-looked-up in the entity queries, so the cost is bounded by the number of mentions being scanned. No sequential scans on `entity_mentions` or `entities`.

## Test plan

- [x] `pytest -q` — 220 pass (210 baseline + 10 new), zero regressions
- [x] `ruff check` + `ruff format --check` — clean
- [x] 10 new integration tests covering all four endpoints and the semantic edge cases:
  - Entity with only-forgotten mentions drops from list + visualize
  - `mention_count` reflects live mentions only (both list and detail)
  - Forgotten chunk's preview text never surfaces via entity detail
  - Related entities filter respects forgotten backing chunks
  - Relationships filter hides forgotten-backed, preserves NULL-chunk_id
  - Visualize edge query hides forgotten-backed edges even between surviving nodes
  - Truncation counter (`total_nodes_available`) uses live-mention definition too

## Follow-up

Introducing a `live_entity_mentions` SQL view (and `live_relationships`) would let every graph query read from the view instead of duplicating the JOIN + predicate. Additive, no data change, natural v1.1 hygiene cleanup — not scoped for this PR.

Closes #109.
