### PR TITLE
chore: bump version to 1.0.10

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       retries: 10
 
   app:
-    image: ghcr.io/mihaibuilds/memory-vault:1.0.9
+    image: ghcr.io/mihaibuilds/memory-vault:1.0.10
     depends_on:
       db:
         condition: service_healthy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "memory-vault"
-version = "1.0.9"
+version = "1.0.10"
 description = "Local-first AI memory system with hybrid search — PostgreSQL + pgvector"
 readme = "README.md"
 license = "MIT"

--- a/server.json
+++ b/server.json
@@ -8,11 +8,11 @@
     "url": "https://github.com/MihaiBuilds/memory-vault",
     "source": "github"
   },
-  "version": "1.0.9",
+  "version": "1.0.10",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/mihaibuilds/memory-vault-mcp:1.0.9",
+      "identifier": "ghcr.io/mihaibuilds/memory-vault-mcp:1.0.10",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Summary

Bumps every version surface to `1.0.10` in preparation for the release tag. `version-guard` checks these four surfaces at tag push and blocks the workflow if any drift.

## Changed

- `pyproject.toml` — `version = "1.0.10"`
- `docker-compose.yml` — `image: ghcr.io/mihaibuilds/memory-vault:1.0.10`
- `server.json` — `"version": "1.0.10"`
- `server.json` — `"identifier": "ghcr.io/mihaibuilds/memory-vault-mcp:1.0.10"`

## Not changed

`CHANGELOG.md` already has the v1.0.10 entry in the right place (PR #130) with `[Unreleased]` above it — no restructure needed at bump time.

## Test plan

- [x] `pytest -q` — 220 pass, zero regressions (version-reporting tests confirm all surfaces agree with `importlib.metadata`, which now returns 1.0.10)
- [x] `ruff check` + `ruff format --check` — clean
- [x] Reinstalled locally, confirmed `memory_vault.__version__ == "1.0.10"`

## Next

After merge, tag `v1.0.10` with a full annotation as the release body. `release.yml` fires the pipeline: `version-guard → docker → publish-mcp-registry → release`. First real exercise of the MCP Registry auto-publish (PR #125).
