### PR TITLE
fix: memory-vault ingest exits non-zero when any chunk fails (#104)

### DIFF
--- a/src/memory_vault/cli.py
+++ b/src/memory_vault/cli.py
@@ -161,6 +161,10 @@ async def _cmd_ingest(file_path: str, space: str) -> None:
 
     await close_pool()
     print(f"Ingested: {stats.chunks_created} chunks created, {stats.failed} failed")
+    if stats.failed > 0:
+        for err in stats.errors:
+            print(f"  {err}")
+        sys.exit(1)
 
 
 async def _cmd_search(query: str, space: str | None, limit: int) -> None:

--- a/tests/test_cli_exit_code.py
+++ b/tests/test_cli_exit_code.py
@@ -20,7 +20,6 @@ import pytest
 import memory_vault.cli as cli_module
 import memory_vault.models.db as db_module
 import memory_vault.services.ingestion as ingestion_module
-from memory_vault.services.ingestion import IngestionStats
 
 pytestmark = pytest.mark.asyncio
 
@@ -28,7 +27,7 @@ pytestmark = pytest.mark.asyncio
 class _StubPipeline:
     """Stand-in for IngestionPipeline that returns a fixed IngestionStats."""
 
-    def __init__(self, stats: IngestionStats):
+    def __init__(self, stats: ingestion_module.IngestionStats):
         self._stats = stats
 
     def __call__(self, *args, **kwargs):
@@ -37,11 +36,13 @@ class _StubPipeline:
     def enqueue(self, *args, **kwargs) -> None:
         pass
 
-    async def run_all(self) -> IngestionStats:
+    async def run_all(self) -> ingestion_module.IngestionStats:
         return self._stats
 
 
-async def _install_stubs(monkeypatch, stats: IngestionStats, tmp_path: Path) -> Path:
+async def _install_stubs(
+    monkeypatch, stats: ingestion_module.IngestionStats, tmp_path: Path
+) -> Path:
     """Patch DB helpers and IngestionPipeline so _cmd_ingest never touches Postgres."""
 
     async def _noop_init_pool(*args, **kwargs) -> None:
@@ -67,7 +68,7 @@ async def _install_stubs(monkeypatch, stats: IngestionStats, tmp_path: Path) -> 
 
 async def test_cli_ingest_exits_nonzero_when_any_chunk_fails(monkeypatch, tmp_path, capsys):
     """A pipeline that reports ``failed > 0`` must make _cmd_ingest sys.exit(1)."""
-    stats = IngestionStats(failed=1, errors=["stub.md: adapter rejected the file"])
+    stats = ingestion_module.IngestionStats(failed=1, errors=["stub.md: adapter rejected the file"])
     dummy_file = await _install_stubs(monkeypatch, stats, tmp_path)
 
     with pytest.raises(SystemExit) as exc_info:
@@ -81,7 +82,7 @@ async def test_cli_ingest_exits_nonzero_when_any_chunk_fails(monkeypatch, tmp_pa
 
 async def test_cli_ingest_returns_normally_on_success(monkeypatch, tmp_path, capsys):
     """A pipeline with zero failures must not call sys.exit."""
-    stats = IngestionStats(chunks_created=3, completed=1, failed=0)
+    stats = ingestion_module.IngestionStats(chunks_created=3, completed=1, failed=0)
     dummy_file = await _install_stubs(monkeypatch, stats, tmp_path)
 
     # Should not raise SystemExit.

--- a/tests/test_cli_exit_code.py
+++ b/tests/test_cli_exit_code.py
@@ -1,0 +1,91 @@
+"""
+CLI exit-code behaviour for `memory-vault ingest`.
+
+Regression guard for issue #104: `_cmd_ingest` printed `stats.failed` but
+never mapped a non-zero failure count to a non-zero process exit code, so
+shell scripts, CI jobs, and agents could not distinguish a complete
+ingestion from a failed one by checking ``$?``.
+
+The reproduction is synthetic — the pipeline is replaced with a stub that
+returns ``IngestionStats(failed=1)``. No real ingestion or database work is
+performed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import memory_vault.cli as cli_module
+import memory_vault.models.db as db_module
+import memory_vault.services.ingestion as ingestion_module
+from memory_vault.services.ingestion import IngestionStats
+
+pytestmark = pytest.mark.asyncio
+
+
+class _StubPipeline:
+    """Stand-in for IngestionPipeline that returns a fixed IngestionStats."""
+
+    def __init__(self, stats: IngestionStats):
+        self._stats = stats
+
+    def __call__(self, *args, **kwargs):
+        return self
+
+    def enqueue(self, *args, **kwargs) -> None:
+        pass
+
+    async def run_all(self) -> IngestionStats:
+        return self._stats
+
+
+async def _install_stubs(monkeypatch, stats: IngestionStats, tmp_path: Path) -> Path:
+    """Patch DB helpers and IngestionPipeline so _cmd_ingest never touches Postgres."""
+
+    async def _noop_init_pool(*args, **kwargs) -> None:
+        return None
+
+    async def _noop_close_pool() -> None:
+        return None
+
+    async def _fetch_default_space(query, params):
+        return {"id": 1}
+
+    monkeypatch.setattr(db_module, "init_pool", _noop_init_pool)
+    monkeypatch.setattr(db_module, "close_pool", _noop_close_pool)
+    monkeypatch.setattr(db_module, "fetch_one", _fetch_default_space)
+
+    stub = _StubPipeline(stats)
+    monkeypatch.setattr(ingestion_module, "IngestionPipeline", stub)
+
+    dummy_file = tmp_path / "input.md"
+    dummy_file.write_text("stub content — never actually ingested\n")
+    return dummy_file
+
+
+async def test_cli_ingest_exits_nonzero_when_any_chunk_fails(monkeypatch, tmp_path, capsys):
+    """A pipeline that reports ``failed > 0`` must make _cmd_ingest sys.exit(1)."""
+    stats = IngestionStats(failed=1, errors=["stub.md: adapter rejected the file"])
+    dummy_file = await _install_stubs(monkeypatch, stats, tmp_path)
+
+    with pytest.raises(SystemExit) as exc_info:
+        await cli_module._cmd_ingest(str(dummy_file), space="default")
+
+    assert exc_info.value.code == 1
+    out = capsys.readouterr().out
+    assert "0 chunks created, 1 failed" in out
+    assert "stub.md: adapter rejected the file" in out
+
+
+async def test_cli_ingest_returns_normally_on_success(monkeypatch, tmp_path, capsys):
+    """A pipeline with zero failures must not call sys.exit."""
+    stats = IngestionStats(chunks_created=3, completed=1, failed=0)
+    dummy_file = await _install_stubs(monkeypatch, stats, tmp_path)
+
+    # Should not raise SystemExit.
+    await cli_module._cmd_ingest(str(dummy_file), space="default")
+
+    out = capsys.readouterr().out
+    assert "3 chunks created, 0 failed" in out


### PR DESCRIPTION
## Summary
Fixes #104. \`memory-vault ingest\` printed \`stats.failed\` but returned normally, exiting 0 even on failures — shell scripts and agents couldn't tell a completed ingestion from a failed one via \`\$?\`.

## Fix
After the existing summary line, when \`stats.failed > 0\`:
- print each error from \`stats.errors\` (previously populated but never surfaced)
- \`sys.exit(1)\`

A fully successful run continues to exit 0.

## Test
\`tests/test_cli_exit_code.py\` — 2 tests, both bypass the DB by monkey-patching \`IngestionPipeline\` + pool helpers, matching the reproduction Leonard described:
- \`test_cli_ingest_exits_nonzero_when_any_chunk_fails\` — stub pipeline returns \`IngestionStats(failed=1)\`, asserts \`SystemExit(1)\` + error text in output
- \`test_cli_ingest_returns_normally_on_success\` — stub with zero failures, asserts no exception

Full suite: 222/222 pass locally. Ruff check + format clean.

Credit: @lcj-codex-coder (Leonard Janke — lcjanke2020, working with GPT-5.6-Sol through OpenAI Codex) for the report.