### PR TITLE
fix: /api/health returns 503 when database unreachable (#108)

### DIFF
--- a/src/memory_vault/api/routers/health.py
+++ b/src/memory_vault/api/routers/health.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Response, status
 
 from memory_vault import __version__
 from memory_vault.api.schemas import HealthResponse
@@ -13,12 +13,21 @@ router = APIRouter(prefix="/api", tags=["health"])
 
 
 @router.get("/health", response_model=HealthResponse)
-async def get_health() -> HealthResponse:
-    """Return API and database health status."""
+async def get_health(response: Response) -> HealthResponse:
+    """Return API and database health status.
+
+    Returns HTTP 200 when the database is reachable, HTTP 503 when it is not.
+    The body always carries the same shape (embedding_model, version) so
+    operators curling the endpoint keep the debug context regardless of
+    outcome. The Docker HEALTHCHECK relies on the status code alone.
+    """
     db = await health_check()
+    healthy = db["status"] == "healthy"
+    if not healthy:
+        response.status_code = status.HTTP_503_SERVICE_UNAVAILABLE
     return HealthResponse(
-        status="ok" if db["status"] == "healthy" else "degraded",
-        database="connected" if db["status"] == "healthy" else "error",
+        status="ok" if healthy else "degraded",
+        database="connected" if healthy else "error",
         embedding_model=MODEL_NAME,
         version=__version__,
     )

--- a/tests/test_api_routers.py
+++ b/tests/test_api_routers.py
@@ -33,6 +33,29 @@ class TestHealth:
         assert body["embedding_model"]
         assert body["version"]
 
+    async def test_health_returns_503_when_db_unhealthy(self, client, monkeypatch):
+        """Regression guard for #108.
+
+        With Postgres unreachable, the endpoint must return HTTP 503 so the
+        Docker HEALTHCHECK (which only inspects the response code) marks the
+        container unhealthy. The body still carries embedding_model and
+        version so operators keep debug context.
+        """
+        import memory_vault.api.routers.health as health_module
+
+        async def _fake_health_check():
+            return {"status": "unhealthy", "error": "simulated db outage"}
+
+        monkeypatch.setattr(health_module, "health_check", _fake_health_check)
+
+        r = await client.get("/api/health")
+        assert r.status_code == 503
+        body = r.json()
+        assert body["status"] == "degraded"
+        assert body["database"] == "error"
+        assert body["embedding_model"]
+        assert body["version"]
+
 
 # ---------------------------------------------------------------------------
 # Authentication


### PR DESCRIPTION
## Summary
Fixes #108. \`/api/health\` returned HTTP 200 with \`status: \"degraded\"\` when the database was unreachable. The Docker \`HEALTHCHECK\` uses \`urllib.request.urlopen\`, which only inspects the status code — so the container stayed \"healthy\" after Postgres went down.

## Fix
When \`health_check()\` reports unhealthy, set \`response.status_code = 503\`. Body shape is preserved in both cases so operators curling the endpoint still see \`embedding_model\` + \`version\` for debugging.

## Test
\`tests/test_api_routers.py::TestHealth::test_health_returns_503_when_db_unhealthy\` — monkey-patches \`health_check\` to simulate a db outage, asserts HTTP 503 + degraded body. Existing happy-path test unchanged.

Full suite: 223/223 pass locally. Ruff check + format clean.

Credit: @lcj-codex-coder (Leonard Janke — lcjanke2020, working with GPT-5.6-Sol through OpenAI Codex) for the report.