### PR TITLE
fix: do not cache a connection pool that failed to initialize

### DIFF
--- a/src/memory_vault/models/db.py
+++ b/src/memory_vault/models/db.py
@@ -22,12 +22,20 @@ MIGRATIONS_DIR = Path(__file__).resolve().parent.parent / "migrations"
 
 
 async def init_pool(min_size: int = 2, max_size: int = 10) -> AsyncConnectionPool:
-    """Create and open the async connection pool."""
+    """Create and open the async connection pool.
+
+    On any failure during construction, ``open()``, or the post-open
+    dimension check, the partially-initialized pool is closed on a
+    best-effort basis and ``_pool`` is cleared before re-raising. This
+    keeps the in-process retry path clean: a later ``init_pool()`` call
+    constructs and opens a fresh pool rather than returning the failed
+    one from the module-level cache.
+    """
     global _pool
     if _pool is not None:
         return _pool
 
-    _pool = AsyncConnectionPool(
+    pool = AsyncConnectionPool(
         conninfo=settings.database_url,
         min_size=min_size,
         max_size=max_size,
@@ -38,10 +46,20 @@ async def init_pool(min_size: int = 2, max_size: int = 10) -> AsyncConnectionPoo
         check=AsyncConnectionPool.check_connection,
         kwargs={"row_factory": dict_row, "autocommit": False},
     )
-    await _pool.open()
-    logger.info("Connection pool opened (min=%d, max=%d)", min_size, max_size)
-
-    await _verify_embedding_dimension()
+    try:
+        await pool.open()
+        _pool = pool
+        logger.info("Connection pool opened (min=%d, max=%d)", min_size, max_size)
+        await _verify_embedding_dimension()
+    except Exception:
+        # Best-effort teardown of any resources the pool acquired before failing;
+        # then clear the module cache so the next init_pool() call retries cleanly.
+        try:
+            await pool.close()
+        except Exception:
+            logger.exception("failed to close pool after init failure")
+        _pool = None
+        raise
 
     return _pool
 

--- a/tests/test_db_pool.py
+++ b/tests/test_db_pool.py
@@ -2,6 +2,7 @@
 
 import psycopg
 import pytest
+from psycopg_pool import AsyncConnectionPool
 
 import memory_vault.models.db as db_module
 from memory_vault.config import settings
@@ -38,3 +39,82 @@ async def test_pool_recovers_from_connection_killed_while_idle(monkeypatch):
             assert (await cur.fetchone())["ok"] == 1
     finally:
         await pool.close()
+
+
+async def test_failed_open_is_not_cached_for_later_calls(monkeypatch):
+    """A pool that fails to open must not be handed to the next caller.
+
+    Regression guard: the module caches the pool in ``_pool``. If the
+    assignment happens before ``open()`` succeeds, a database that is merely
+    slow to accept connections at boot poisons the cache — every later
+    ``init_pool()`` returns the dead pool and the process never recovers
+    without a restart.
+    """
+    monkeypatch.setattr(db_module, "_pool", None)
+
+    closed: list[bool] = []
+
+    async def failing_open(self):
+        raise psycopg.OperationalError("connection refused")
+
+    async def record_close(self):
+        closed.append(True)
+
+    monkeypatch.setattr(AsyncConnectionPool, "open", failing_open)
+    monkeypatch.setattr(AsyncConnectionPool, "close", record_close)
+
+    with pytest.raises(psycopg.OperationalError):
+        await init_pool()
+
+    assert db_module._pool is None, "failed pool was cached"
+    assert closed == [True], "failed pool was not closed"
+
+    # The database comes back: a later call must build and open a fresh pool.
+    opened: list[bool] = []
+
+    async def working_open(self):
+        opened.append(True)
+
+    async def noop_verify():
+        return None
+
+    monkeypatch.setattr(AsyncConnectionPool, "open", working_open)
+    monkeypatch.setattr(db_module, "_verify_embedding_dimension", noop_verify)
+
+    pool = await init_pool()
+
+    assert opened == [True]
+    assert db_module._pool is pool
+
+
+async def test_failed_dimension_check_is_not_cached(monkeypatch):
+    """The post-open verification failing must clear the cache too.
+
+    ``_verify_embedding_dimension`` runs after ``open()`` and reaches the
+    database through ``get_pool()``, so the pool has to be visible in
+    ``_pool`` while it runs. If that assignment is left in place when the
+    check raises, a misconfigured process keeps serving from a pool it
+    already decided was unusable.
+    """
+    monkeypatch.setattr(db_module, "_pool", None)
+
+    closed: list[bool] = []
+
+    async def working_open(self):
+        return None
+
+    async def record_close(self):
+        closed.append(True)
+
+    async def failing_verify():
+        raise RuntimeError("EMBEDDING_DIMENSIONS mismatch")
+
+    monkeypatch.setattr(AsyncConnectionPool, "open", working_open)
+    monkeypatch.setattr(AsyncConnectionPool, "close", record_close)
+    monkeypatch.setattr(db_module, "_verify_embedding_dimension", failing_verify)
+
+    with pytest.raises(RuntimeError, match="EMBEDDING_DIMENSIONS"):
+        await init_pool()
+
+    assert db_module._pool is None, "pool cached after dimension check failed"
+    assert closed == [True], "pool was not closed after dimension check failed"


### PR DESCRIPTION
## Problem

`init_pool()` cached the pool before it was open:

```python
_pool = AsyncConnectionPool(...)   # cached here
await _pool.open()                 # ...but this can raise
```

The function returns early when `_pool is not None`. So if `open()` raised — database not yet accepting connections at container start, wrong credentials, unreachable host — the broken pool stayed in the module cache, and every later `init_pool()` call handed it straight back. The process could not recover without a restart, even once the database came up.

## Fix

The pool is assigned to `_pool` only after `open()` succeeds. If `open()` or the embedding-dimension check that follows it raises, the partially-initialized pool is closed on a best-effort basis, the cache is cleared, and the error is re-raised. A later call then builds and opens a fresh pool.

`_verify_embedding_dimension()` reaches the database through `get_pool()`, so it needs the pool visible in `_pool` while it runs. That assignment happens inside the `try` and is unwound by the same `except` branch when the check fails.

## Tests

Two regression tests in `tests/test_db_pool.py`, both verified to fail against the unfixed code:

- `test_failed_open_is_not_cached_for_later_calls` — `open()` raises `OperationalError`; asserts the cache is cleared and the failed pool closed, then that a later call opens a fresh pool once the database is back.
- `test_failed_dimension_check_is_not_cached` — `open()` succeeds but the dimension check raises; asserts the cache is cleared and the pool closed.

245/245 pytest, `ruff check` and `ruff format --check` clean.

Closes #117

Reported by @lcj-codex-coder.
