### PR TITLE
fix: make exact-duplicate detection atomic in MCP remember

### DIFF
--- a/src/memory_vault/mcp/server.py
+++ b/src/memory_vault/mcp/server.py
@@ -41,6 +41,7 @@ from mcp.server.fastmcp import FastMCP  # noqa: E402
 
 from memory_vault.models.db import (  # noqa: E402
     execute_query,
+    execute_returning,
     fetch_all,
     fetch_one,
     health_check,
@@ -290,36 +291,46 @@ async def remember(
         embedding = await asyncio.to_thread(embed, text)
         content_hash = hashlib.sha256(text.encode()).hexdigest()
 
-        # Check for exact duplicate (same hash in same space)
-        dup = await fetch_one(
-            """SELECT id FROM chunks
-               WHERE space_id = %s
-                 AND metadata->>'content_hash' = %s""",
-            (space_id, content_hash),
-        )
-        if dup:
-            return _dumps(
-                {
-                    "stored": False,
-                    "duplicate": True,
-                    "existing_chunk_id": str(dup["id"]),
-                    "message": "This memory already exists (exact duplicate).",
-                }
-            )
-
         # Classify
         category, importance = _classify_memory(text)
         meta = json.dumps({"category": category, "source": source, "content_hash": content_hash})
 
         chunk_id = str(uuid.uuid4())
 
-        await execute_query(
+        # Insert and detect the duplicate in one statement. A separate
+        # SELECT-then-INSERT left a window where two concurrent calls both saw
+        # no duplicate and both stored the memory (#111); the unique index from
+        # migration 004 plus ON CONFLICT closes it. RETURNING yields no row when
+        # the conflict fires, which is how the duplicate case is recognised.
+        inserted = await execute_returning(
             """INSERT INTO chunks
                    (id, space_id, chunk_index, speaker, content, embedding,
                     source, importance, metadata)
-               VALUES (%s, %s, 0, %s, %s, %s::vector, %s, %s, %s::jsonb)""",
+               VALUES (%s, %s, 0, %s, %s, %s::vector, %s, %s, %s::jsonb)
+               ON CONFLICT (space_id, (metadata->>'content_hash'))
+                   WHERE metadata->>'content_hash' IS NOT NULL
+                   DO NOTHING
+               RETURNING id""",
             (chunk_id, space_id, speaker, text, str(embedding), f"mcp:{source}", importance, meta),
         )
+
+        if inserted is None:
+            # The row already existed, or a concurrent call won the race. Either
+            # way the caller gets the same answer as before: the existing chunk.
+            existing = await fetch_one(
+                """SELECT id FROM chunks
+                   WHERE space_id = %s
+                     AND metadata->>'content_hash' = %s""",
+                (space_id, content_hash),
+            )
+            return _dumps(
+                {
+                    "stored": False,
+                    "duplicate": True,
+                    "existing_chunk_id": str(existing["id"]) if existing else None,
+                    "message": "This memory already exists (exact duplicate).",
+                }
+            )
 
         # Best-effort graph extraction — mirrors REST/file ingestion. The
         # helper swallows extraction errors so the chunk stays committed;

--- a/src/memory_vault/migrations/004_chunk_content_hash_dedup.sql
+++ b/src/memory_vault/migrations/004_chunk_content_hash_dedup.sql
@@ -1,0 +1,34 @@
+-- Memory Vault — enforce exact-duplicate detection in the database
+--
+-- The MCP `remember` tool checked for an existing content hash and then
+-- inserted in a separate statement. Two concurrent calls could both pass the
+-- check before either insert ran, so both stored the same memory. No database
+-- constraint backed the guarantee the tool advertised.
+--
+-- Scope: this index covers rows that carry metadata->>'content_hash', which
+-- today means rows written by MCP `remember`. File ingestion and ingest_text
+-- do not persist a content hash, so their rows have NULL here and are not
+-- constrained -- NULLs are never equal in a unique index, so they would be
+-- exempt whether or not the WHERE clause is present. The predicate makes that
+-- scope explicit rather than implied, and keeps the index off rows it can
+-- never apply to. Widening the invariant to the ingestion paths means
+-- persisting the hash there first; that is deliberately not done here.
+
+-- Collapse any duplicates already committed by the pre-fix race, keeping the
+-- oldest row of each group. Without this, CREATE UNIQUE INDEX fails on a
+-- database that hit the bug and the container will not finish booting.
+WITH ranked AS (
+    SELECT id,
+           row_number() OVER (
+               PARTITION BY space_id, metadata->>'content_hash'
+               ORDER BY created_at, id
+           ) AS rn
+    FROM chunks
+    WHERE metadata->>'content_hash' IS NOT NULL
+)
+DELETE FROM chunks
+WHERE id IN (SELECT id FROM ranked WHERE rn > 1);
+
+CREATE UNIQUE INDEX chunks_space_content_hash_idx
+    ON chunks (space_id, (metadata->>'content_hash'))
+    WHERE metadata->>'content_hash' IS NOT NULL;

--- a/src/memory_vault/models/db.py
+++ b/src/memory_vault/models/db.py
@@ -144,6 +144,31 @@ async def fetch_one(
         return await cur.fetchone()  # type: ignore[return-value]
 
 
+async def execute_returning(
+    sql: str,
+    params: tuple | dict | None = None,
+) -> dict[str, Any] | None:
+    """Execute a DML statement with RETURNING and commit. Returns the row, or None.
+
+    `fetch_one` leaves the commit to psycopg's context manager, which is fine
+    for reads but leaves a write's durability resting on an implicit detail.
+    This helper commits explicitly and rolls back on error, matching
+    `execute_query`, while still handing back the RETURNING row that
+    distinguishes an insert from an `ON CONFLICT DO NOTHING` no-op.
+    """
+    pool = await get_pool()
+    async with pool.connection() as conn:
+        try:
+            cur = await conn.execute(sql, params)
+            row = await cur.fetchone()
+            await conn.commit()
+            return row  # type: ignore[return-value]
+        except Exception:
+            await conn.rollback()
+            logger.exception("execute_returning failed — SQL: %s", sql)
+            raise
+
+
 async def fetch_all(
     sql: str,
     params: tuple | dict | None = None,

--- a/tests/test_mcp_remember_concurrent_dedup.py
+++ b/tests/test_mcp_remember_concurrent_dedup.py
@@ -1,0 +1,140 @@
+"""Exact-duplicate detection in MCP `remember` holds under concurrency."""
+
+import asyncio
+import json
+
+import pytest
+
+from memory_vault.models.db import execute_query, fetch_all, fetch_one
+
+pytestmark = pytest.mark.asyncio
+
+SPACE = "dedup-race"
+TEXT = "same concurrent memory"
+
+
+async def _space_id() -> int:
+    await execute_query(
+        "INSERT INTO memory_spaces (name) VALUES (%s) ON CONFLICT (name) DO NOTHING",
+        (SPACE,),
+        commit=True,
+    )
+    row = await fetch_one("SELECT id FROM memory_spaces WHERE name = %s", (SPACE,))
+    return row["id"]
+
+
+async def _stored_chunks(space_id: int) -> list[dict]:
+    return await fetch_all(
+        """SELECT id FROM chunks
+           WHERE space_id = %s AND content = %s""",
+        (space_id, TEXT),
+    )
+
+
+async def test_concurrent_remember_stores_one_chunk(monkeypatch):
+    """Two simultaneous `remember` calls with identical text store one chunk.
+
+    Regression guard for #111. The tool used to SELECT for an existing content
+    hash and INSERT in a separate statement, so two callers could both see no
+    duplicate and both commit. The barrier below holds each call at the moment
+    the old code had finished its duplicate lookup, which is the interleaving
+    that made the race deterministic rather than occasional.
+    """
+    from memory_vault.mcp import server
+
+    space_id = await _space_id()
+
+    # Stub the embedding. This test is about database concurrency, and running
+    # the real model on two threads at once crashes the process — the shared
+    # SentenceTransformer is not safe for parallel `encode` calls. A fixed
+    # vector keeps the test on the behaviour it is actually asserting.
+    monkeypatch.setattr(server, "embed", lambda text: [0.1] * 384)
+
+    # Deterministic interleaving: neither call proceeds to its write until both
+    # have passed the point where the duplicate check used to happen.
+    barrier = asyncio.Barrier(2)
+    real_to_thread = asyncio.to_thread
+
+    async def gated_to_thread(fn, *args, **kwargs):
+        result = await real_to_thread(fn, *args, **kwargs)
+        # Gate only the embed call inside `remember`, and only once per caller.
+        # Graph extraction also runs through `to_thread` on the same text, but
+        # only the winning caller reaches it — waiting there would block on a
+        # partner that already returned.
+        if fn is server.embed:
+            await barrier.wait()
+        return result
+
+    monkeypatch.setattr(server.asyncio, "to_thread", gated_to_thread)
+
+    # Bounded so a barrier that never releases fails the test instead of
+    # hanging the suite.
+    first, second = await asyncio.wait_for(
+        asyncio.gather(
+            server.remember(TEXT, space=SPACE),
+            server.remember(TEXT, space=SPACE),
+        ),
+        timeout=60,
+    )
+
+    results = [json.loads(first), json.loads(second)]
+    stored = [r for r in results if r.get("stored")]
+    duplicates = [r for r in results if r.get("duplicate")]
+
+    assert len(stored) == 1, f"expected exactly one store, got {results}"
+    assert len(duplicates) == 1, f"expected exactly one duplicate, got {results}"
+
+    rows = await _stored_chunks(space_id)
+    assert len(rows) == 1, f"expected one chunk in the database, found {len(rows)}"
+
+    # The losing caller still learns which chunk holds the memory.
+    assert duplicates[0]["existing_chunk_id"] == str(rows[0]["id"])
+
+
+async def test_sequential_duplicate_still_reports_existing_chunk():
+    """The ordinary (non-racing) duplicate path keeps its contract.
+
+    The fix moved duplicate detection from a SELECT into ON CONFLICT, so the
+    plain case is worth pinning too: same answer, same shape, and no second
+    chunk written.
+    """
+    from memory_vault.mcp import server
+
+    space_id = await _space_id()
+
+    first = json.loads(await server.remember(TEXT, space=SPACE))
+    second = json.loads(await server.remember(TEXT, space=SPACE))
+
+    assert first["stored"] is True
+    assert second["stored"] is False
+    assert second["duplicate"] is True
+    assert second["existing_chunk_id"] == first["chunk_id"]
+
+    rows = await _stored_chunks(space_id)
+    assert len(rows) == 1
+
+
+async def test_ingestion_rows_without_content_hash_are_not_constrained():
+    """Rows carrying no content hash stay exempt from the unique index.
+
+    File ingestion and `ingest_text` do not persist a content hash, so their
+    rows hold NULL at the indexed expression. The index is deliberately
+    partial: it must not start rejecting those writes, which would change
+    ingestion behaviour well beyond the bug being fixed here.
+    """
+    space_id = await _space_id()
+
+    for _ in range(2):
+        await execute_query(
+            """INSERT INTO chunks (space_id, content, metadata)
+               VALUES (%s, %s, %s::jsonb)""",
+            (space_id, "ingested text", json.dumps({"source_file": "a.md"})),
+            commit=True,
+        )
+
+    rows = await fetch_all(
+        """SELECT id FROM chunks
+           WHERE space_id = %s AND content = %s""",
+        (space_id, "ingested text"),
+    )
+    assert len(rows) == 2


### PR DESCRIPTION
## Problem

`remember` checked for an existing content hash and inserted in two separate statements:

```python
dup = await fetch_one("SELECT id FROM chunks WHERE space_id = %s AND metadata->>'content_hash' = %s", ...)
if dup:
    return {"duplicate": True, ...}
...
await execute_query("INSERT INTO chunks ...")
```

Nothing held a lock across the gap, and no constraint backed the guarantee the tool advertised. Two concurrent calls with identical text could both pass the check and both commit, and both callers were told the memory was stored.

## Fix

Migration 004 adds a unique index on `(space_id, content_hash)`, and the insert uses `ON CONFLICT DO NOTHING` with `RETURNING id`. The database decides the winner. An empty `RETURNING` marks the losing caller, which re-reads the existing row and returns the same duplicate response the tool returned before — same shape, same `existing_chunk_id`.

The write also moved to a helper that commits explicitly rather than relying on the connection context manager, since it is now a statement whose result is inspected.

### Why the index is partial

It covers rows carrying `metadata->>'content_hash'`, which today means rows written by `remember`. File ingestion and `ingest_text` do not persist a content hash, so their rows hold NULL at the indexed expression — and NULLs never compare equal, so those rows would be exempt from a plain unique index anyway. Verified directly:

```
INSERT INTO c (space_id, metadata) VALUES (1, '{"source_file":"a.md"}');  -- ok
INSERT INTO c (space_id, metadata) VALUES (1, '{"source_file":"a.md"}');  -- ok, 2 rows
INSERT INTO c (space_id, metadata) VALUES (1, '{"content_hash":"abc"}');  -- ok
INSERT INTO c (space_id, metadata) VALUES (1, '{"content_hash":"abc"}');  -- ERROR: duplicate key
```

The predicate makes that scope explicit instead of leaving it implied, and keeps the index off rows it can never apply to. Extending the invariant to the ingestion paths means persisting a hash there first, which would change what ingestion writes and is not part of this fix.

### Upgrade safety

A database that already hit the race holds duplicate rows, and `CREATE UNIQUE INDEX` on it would fail and leave the container unable to finish booting. The migration collapses those first, keeping the oldest row of each group.

## Tests

Three tests in `tests/test_mcp_remember_concurrent_dedup.py`:

- `test_concurrent_remember_stores_one_chunk` — two calls held at a barrier until both pass the point where the old duplicate check ran, reproducing the reported interleaving. Against the code before this change it fails with `assert 2 == 1`: both callers reported `stored: true`.
- `test_sequential_duplicate_still_reports_existing_chunk` — the ordinary duplicate path keeps its contract now that detection moved into `ON CONFLICT`.
- `test_ingestion_rows_without_content_hash_are_not_constrained` — rows with no content hash stay insertable, so ingestion behaviour is unchanged.

248/248 pytest against a fresh database, `ruff check` and `ruff format --check` clean.

The concurrency test stubs the embedding model. Running the real one on two threads at once crashes the process — that is a separate defect, filed as #148.

Closes #111

Reported by @lcj-codex-coder.
