### PR TITLE
fix: make file ingestion atomic and idempotent on retry

### DIFF
--- a/src/memory_vault/mcp/server.py
+++ b/src/memory_vault/mcp/server.py
@@ -309,6 +309,7 @@ async def remember(
                VALUES (%s, %s, 0, %s, %s, %s::vector, %s, %s, %s::jsonb)
                ON CONFLICT (space_id, (metadata->>'content_hash'))
                    WHERE metadata->>'content_hash' IS NOT NULL
+                     AND metadata->>'source_file' IS NULL
                    DO NOTHING
                RETURNING id""",
             (chunk_id, space_id, speaker, text, str(embedding), f"mcp:{source}", importance, meta),

--- a/src/memory_vault/migrations/004_chunk_content_hash_dedup.sql
+++ b/src/memory_vault/migrations/004_chunk_content_hash_dedup.sql
@@ -6,13 +6,16 @@
 -- constraint backed the guarantee the tool advertised.
 --
 -- Scope: this index covers rows that carry metadata->>'content_hash', which
--- today means rows written by MCP `remember`. File ingestion and ingest_text
--- do not persist a content hash, so their rows have NULL here and are not
--- constrained -- NULLs are never equal in a unique index, so they would be
--- exempt whether or not the WHERE clause is present. The predicate makes that
--- scope explicit rather than implied, and keeps the index off rows it can
--- never apply to. Widening the invariant to the ingestion paths means
--- persisting the hash there first; that is deliberately not done here.
+-- at the time of this migration means rows written by MCP `remember`. File
+-- ingestion and ingest_text do not persist a content hash, so their rows have
+-- NULL here and are not constrained -- NULLs are never equal in a unique
+-- index, so they would be exempt whether or not the WHERE clause is present.
+-- The predicate makes that scope explicit rather than implied, and keeps the
+-- index off rows it can never apply to.
+--
+-- Superseded by migration 006: once ingestion began persisting a content hash
+-- of its own, "carries a content hash" stopped meaning "was stored through
+-- remember", and this predicate had to be narrowed to match its intent.
 
 -- Collapse any duplicates already committed by the pre-fix race, keeping the
 -- oldest row of each group. Without this, CREATE UNIQUE INDEX fails on a

--- a/src/memory_vault/migrations/005_chunk_ingest_identity.sql
+++ b/src/memory_vault/migrations/005_chunk_ingest_identity.sql
@@ -1,0 +1,36 @@
+-- Memory Vault — make file ingestion idempotent on retry
+--
+-- Each chunk of a file was inserted and committed on its own. A failure
+-- partway through left the earlier chunks committed, and retrying the file
+-- appended a second copy of every chunk that had already landed.
+--
+-- Two things fix that. The ingestion loop now runs inside one transaction, so
+-- a failed file commits nothing. This index is the durable half: it gives a
+-- chunk an identity, so re-inserting the same chunk of the same file is a
+-- no-op rather than a duplicate, no matter which code path does the writing.
+--
+-- The key is (space, source file, chunk index, content hash) rather than the
+-- content hash alone. Hashing content by itself would treat two legitimately
+-- identical passages in one document -- a repeated line in a changelog, the
+-- same phrase in two transcript turns -- as duplicates and silently drop the
+-- second. Including the chunk index keeps those distinct while still
+-- collapsing a genuine retry, which re-parses the file and produces the same
+-- chunk at the same index. The hash stays in the key so that editing a file
+-- and re-ingesting it replaces nothing silently: changed content is a
+-- different chunk identity and inserts normally.
+--
+-- Scope: rows that carry both markers in metadata, which means rows written by
+-- file ingestion from here on. Rows already stored have no content hash and
+-- are exempt; they were never at risk from a future retry, and rewriting every
+-- existing row to backfill a hash would mean a full table rewrite on upgrade
+-- for no correctness gain.
+
+CREATE UNIQUE INDEX chunks_ingest_identity_idx
+    ON chunks (
+        space_id,
+        (metadata->>'source_file'),
+        chunk_index,
+        (metadata->>'content_hash')
+    )
+    WHERE metadata->>'content_hash' IS NOT NULL
+      AND metadata->>'source_file' IS NOT NULL;

--- a/src/memory_vault/migrations/006_scope_remember_dedup_index.sql
+++ b/src/memory_vault/migrations/006_scope_remember_dedup_index.sql
@@ -1,0 +1,27 @@
+-- Memory Vault — confine the remember-dedup index to stored memories
+--
+-- Migration 004 added a unique index on (space_id, content_hash) to stop two
+-- concurrent `remember` calls storing the same memory twice. At the time only
+-- `remember` persisted a content hash, so "one content hash per space" and
+-- "one stored memory per space" meant the same thing.
+--
+-- File ingestion now persists a content hash too, so that a retry can
+-- recognise chunks it already wrote. That makes the old index wrong for
+-- ingested rows in two ways. A single document may legitimately repeat a
+-- passage -- a line restated in a changelog, a phrase said twice in a
+-- transcript -- and two unrelated documents may share a paragraph. Under the
+-- 004 index the second occurrence is rejected, so ingesting an ordinary file
+-- fails outright.
+--
+-- The fix is to say what 004 meant: the constraint belongs to memories stored
+-- through `remember`, which never carry a source file. Chunks from ingestion
+-- are covered instead by the identity index in migration 005, which includes
+-- the source file and chunk position and so distinguishes a repeated passage
+-- from a repeated write.
+
+DROP INDEX IF EXISTS chunks_space_content_hash_idx;
+
+CREATE UNIQUE INDEX chunks_space_content_hash_idx
+    ON chunks (space_id, (metadata->>'content_hash'))
+    WHERE metadata->>'content_hash' IS NOT NULL
+      AND metadata->>'source_file' IS NULL;

--- a/src/memory_vault/services/ingestion.py
+++ b/src/memory_vault/services/ingestion.py
@@ -15,13 +15,15 @@ from dataclasses import dataclass, field
 from enum import IntEnum
 from pathlib import Path
 
+from psycopg import AsyncConnection
+
 from memory_vault.adapters.base import RawChunk, detect_adapter
 from memory_vault.extraction import (
     extract_entities,
     extract_relationships,
     write_graph_for_chunk,
 )
-from memory_vault.models.db import execute_query, fetch_one
+from memory_vault.models.db import execute_query, fetch_one, get_pool
 from memory_vault.services.embedding import embed_batch
 
 logger = logging.getLogger(__name__)
@@ -138,39 +140,76 @@ class IngestionPipeline:
         texts = [c.text for c in raw_chunks]
         embeddings = await asyncio.to_thread(embed_batch, texts)
 
-        # Insert each chunk
-        for chunk, emb in zip(raw_chunks, embeddings, strict=True):
-            await self._insert_chunk(chunk, emb, space_id)
+        # One transaction for the whole file. Committing per chunk left the
+        # earlier chunks behind when a later one failed, and retrying the file
+        # then appended a second copy of everything already stored (#115).
+        pool = await get_pool()
+        inserted: list[tuple[str, str]] = []
+        async with pool.connection() as conn:
+            async with conn.transaction():
+                for chunk, emb in zip(raw_chunks, embeddings, strict=True):
+                    chunk_id = await self._insert_chunk(conn, chunk, emb, space_id)
+                    if chunk_id is not None:
+                        inserted.append((chunk_id, chunk.text))
+
+        self._stats.chunks_created += len(inserted)
+
+        # Extraction runs after the chunks are durable, and deliberately
+        # outside the transaction: it is best-effort, and a failure in it must
+        # not roll back a file that stored correctly.
+        for chunk_id, text in inserted:
+            await _run_extraction(chunk_id, text, space_id)
 
     async def _insert_chunk(
         self,
+        conn: AsyncConnection,
         chunk: RawChunk,
         embedding: list[float],
         space_id: int,
-    ) -> None:
-        chunk_id = str(uuid.uuid4())
-        meta_json = json.dumps(chunk.metadata, default=str)
+    ) -> str | None:
+        """Insert one chunk on the caller's connection.
 
-        await execute_query(
+        Returns the new chunk's id, or None when this chunk of this file was
+        already stored — the retry case, which migration 005 turns into a
+        no-op instead of a duplicate.
+        """
+        chunk_id = str(uuid.uuid4())
+        source_file = chunk.metadata.get("source_file", "")
+        # The identity markers migration 005 indexes. Persisting them is what
+        # lets a retry recognise work it already did; without them every retry
+        # looks like fresh content.
+        metadata = {
+            **chunk.metadata,
+            "content_hash": chunk.content_hash,
+            "source_file": source_file,
+        }
+        meta_json = json.dumps(metadata, default=str)
+
+        cur = await conn.execute(
             """INSERT INTO chunks
                    (id, space_id, content, embedding, source, speaker,
                     metadata, chunk_index, created_at)
-               VALUES (%s, %s, %s, %s::vector, %s, %s, %s::jsonb, %s, COALESCE(%s, now()))""",
+               VALUES (%s, %s, %s, %s::vector, %s, %s, %s::jsonb, %s, COALESCE(%s, now()))
+               ON CONFLICT (space_id, (metadata->>'source_file'), chunk_index,
+                            (metadata->>'content_hash'))
+                   WHERE metadata->>'content_hash' IS NOT NULL
+                     AND metadata->>'source_file' IS NOT NULL
+                   DO NOTHING
+               RETURNING id""",
             (
                 chunk_id,
                 space_id,
                 chunk.text,
                 str(embedding),
-                chunk.metadata.get("source_file", ""),
+                source_file,
                 chunk.speaker,
                 meta_json,
                 chunk.chunk_index,
                 chunk.timestamp,
             ),
         )
-        self._stats.chunks_created += 1
-
-        await _run_extraction(chunk_id, chunk.text, space_id)
+        row = await cur.fetchone()
+        return chunk_id if row else None
 
 
 async def ingest_text(

--- a/tests/test_ingest_atomicity.py
+++ b/tests/test_ingest_atomicity.py
@@ -5,7 +5,9 @@ import json
 import pytest
 
 from memory_vault.models.db import execute_query, fetch_all, fetch_one
-from memory_vault.services.ingestion import IngestionPipeline
+from memory_vault.services import ingestion as ing
+
+IngestionPipeline = ing.IngestionPipeline
 
 pytestmark = pytest.mark.asyncio
 
@@ -44,8 +46,6 @@ def _stub_embedding(monkeypatch):
     They exercise transaction and conflict behaviour, not embedding quality,
     and the shared model cannot be driven from several threads safely (#148).
     """
-    import memory_vault.services.ingestion as ing
-
     monkeypatch.setattr(ing, "embed_batch", lambda texts, **kw: [[0.1] * 384 for _ in texts])
 
 
@@ -56,8 +56,6 @@ async def test_failed_file_leaves_no_partial_chunks(tmp_path, monkeypatch):
     a file that failed on its third chunk left the first two behind with
     nothing recording that the file was incomplete.
     """
-    import memory_vault.services.ingestion as ing
-
     space_id = await _space_id()
     path = _write(tmp_path, "partial.md", "# A\n\nfirst\n\n# B\n\nsecond\n\n# C\n\nthird\n")
 
@@ -88,8 +86,6 @@ async def test_failed_file_leaves_no_partial_chunks(tmp_path, monkeypatch):
 
 async def test_retry_after_failure_produces_no_duplicates(tmp_path, monkeypatch):
     """Re-ingesting a file that failed once stores each chunk exactly once."""
-    import memory_vault.services.ingestion as ing
-
     space_id = await _space_id()
     path = _write(tmp_path, "retry.md", "# A\n\nalpha\n\n# B\n\nbeta\n")
 

--- a/tests/test_ingest_atomicity.py
+++ b/tests/test_ingest_atomicity.py
@@ -1,0 +1,176 @@
+"""File ingestion is atomic on failure and idempotent on retry."""
+
+import json
+
+import pytest
+
+from memory_vault.models.db import execute_query, fetch_all, fetch_one
+from memory_vault.services.ingestion import IngestionPipeline
+
+pytestmark = pytest.mark.asyncio
+
+SPACE = "ingest-atomicity"
+
+
+async def _space_id() -> int:
+    await execute_query(
+        "INSERT INTO memory_spaces (name) VALUES (%s) ON CONFLICT (name) DO NOTHING",
+        (SPACE,),
+        commit=True,
+    )
+    row = await fetch_one("SELECT id FROM memory_spaces WHERE name = %s", (SPACE,))
+    return row["id"]
+
+
+async def _chunks_for(space_id: int, source_file: str) -> list[dict]:
+    return await fetch_all(
+        """SELECT id, content, chunk_index FROM chunks
+           WHERE space_id = %s AND metadata->>'source_file' = %s
+           ORDER BY chunk_index""",
+        (space_id, source_file),
+    )
+
+
+def _write(tmp_path, name: str, body: str) -> str:
+    path = tmp_path / name
+    path.write_text(body, encoding="utf-8")
+    return str(path)
+
+
+@pytest.fixture(autouse=True)
+def _stub_embedding(monkeypatch):
+    """Keep the real model out of these tests.
+
+    They exercise transaction and conflict behaviour, not embedding quality,
+    and the shared model cannot be driven from several threads safely (#148).
+    """
+    import memory_vault.services.ingestion as ing
+
+    monkeypatch.setattr(ing, "embed_batch", lambda texts, **kw: [[0.1] * 384 for _ in texts])
+
+
+async def test_failed_file_leaves_no_partial_chunks(tmp_path, monkeypatch):
+    """A failure partway through a file commits nothing.
+
+    Regression guard for #115. Each chunk used to be committed on its own, so
+    a file that failed on its third chunk left the first two behind with
+    nothing recording that the file was incomplete.
+    """
+    import memory_vault.services.ingestion as ing
+
+    space_id = await _space_id()
+    path = _write(tmp_path, "partial.md", "# A\n\nfirst\n\n# B\n\nsecond\n\n# C\n\nthird\n")
+
+    pipeline = IngestionPipeline()
+    real_insert = ing.IngestionPipeline._insert_chunk
+    calls = {"n": 0}
+
+    # Wrapped with *args so the injection does not depend on the insert
+    # helper's signature — otherwise this test can fail for the wrong reason
+    # when run against a different arrangement of the code.
+    async def failing_insert(self, *args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 3:
+            raise RuntimeError("injected failure on the third chunk")
+        return await real_insert(self, *args, **kwargs)
+
+    monkeypatch.setattr(ing.IngestionPipeline, "_insert_chunk", failing_insert)
+
+    pipeline.enqueue(path, space_id)
+    stats = await pipeline.run_all()
+
+    assert stats.failed == 1, "the file should be reported as failed"
+    assert calls["n"] == 3, "the failure should fire on the third insert"
+
+    rows = await _chunks_for(space_id, path)
+    assert rows == [], f"failed file left {len(rows)} chunk(s) behind"
+
+
+async def test_retry_after_failure_produces_no_duplicates(tmp_path, monkeypatch):
+    """Re-ingesting a file that failed once stores each chunk exactly once."""
+    import memory_vault.services.ingestion as ing
+
+    space_id = await _space_id()
+    path = _write(tmp_path, "retry.md", "# A\n\nalpha\n\n# B\n\nbeta\n")
+
+    real_insert = ing.IngestionPipeline._insert_chunk
+    calls = {"n": 0}
+
+    async def failing_insert(self, *args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 2:
+            raise RuntimeError("injected failure")
+        return await real_insert(self, *args, **kwargs)
+
+    monkeypatch.setattr(ing.IngestionPipeline, "_insert_chunk", failing_insert)
+    first = IngestionPipeline()
+    first.enqueue(path, space_id)
+    assert (await first.run_all()).failed == 1
+
+    # Retry with the failure removed.
+    monkeypatch.setattr(ing.IngestionPipeline, "_insert_chunk", real_insert)
+    second = IngestionPipeline()
+    second.enqueue(path, space_id)
+    assert (await second.run_all()).failed == 0
+
+    rows = await _chunks_for(space_id, path)
+    contents = [r["content"] for r in rows]
+    assert len(rows) == 2, f"expected 2 chunks after retry, found {len(rows)}: {contents}"
+    assert len(set(contents)) == 2, f"retry duplicated content: {contents}"
+
+
+async def test_reingesting_an_unchanged_file_is_a_no_op(tmp_path):
+    """Ingesting the same file twice does not double its chunks."""
+    space_id = await _space_id()
+    path = _write(tmp_path, "stable.md", "# A\n\nalpha\n\n# B\n\nbeta\n")
+
+    for _ in range(2):
+        pipeline = IngestionPipeline()
+        pipeline.enqueue(path, space_id)
+        assert (await pipeline.run_all()).failed == 0
+
+    rows = await _chunks_for(space_id, path)
+    assert len(rows) == 2, f"second ingest added chunks: found {len(rows)}"
+
+
+async def test_repeated_passages_in_one_file_are_all_stored(tmp_path):
+    """Two identical passages in one file both survive ingestion.
+
+    Keying idempotency on the content hash alone would treat the second copy
+    as a duplicate and silently drop it. Repeated text is ordinary in
+    changelogs, logs, and transcripts, so the chunk's position is part of its
+    identity.
+    """
+    space_id = await _space_id()
+    body = "# v1.1\n\nFixed the connection pool bug.\n\n# v1.0\n\nFixed the connection pool bug.\n"
+    path = _write(tmp_path, "changelog.md", body)
+
+    pipeline = IngestionPipeline()
+    pipeline.enqueue(path, space_id)
+    assert (await pipeline.run_all()).failed == 0
+
+    rows = await _chunks_for(space_id, path)
+    assert len(rows) == 2, f"a legitimately repeated passage was dropped: {rows}"
+    assert rows[0]["content"] == rows[1]["content"]
+    assert rows[0]["chunk_index"] != rows[1]["chunk_index"]
+
+
+async def test_ingested_chunks_carry_identity_metadata(tmp_path):
+    """Ingestion persists the markers the retry guarantee depends on."""
+    space_id = await _space_id()
+    path = _write(tmp_path, "meta.md", "# A\n\nalpha\n")
+
+    pipeline = IngestionPipeline()
+    pipeline.enqueue(path, space_id)
+    assert (await pipeline.run_all()).failed == 0
+
+    row = await fetch_one(
+        "SELECT metadata FROM chunks WHERE space_id = %s AND metadata->>'source_file' = %s",
+        (space_id, path),
+    )
+    metadata = row["metadata"]
+    if isinstance(metadata, str):
+        metadata = json.loads(metadata)
+
+    assert metadata["source_file"] == path
+    assert metadata["content_hash"], "content_hash must be persisted for retry idempotency"


### PR DESCRIPTION
## Problem

`_process_file` inserted each chunk through `execute_query`, which commits by default:

```python
for chunk, emb in zip(raw_chunks, embeddings, strict=True):
    await self._insert_chunk(chunk, emb, space_id)   # commits, one by one
```

A file that failed on its third chunk left the first two committed, with nothing marking the file as incomplete. Retrying it re-parsed from the start and appended a second copy of everything already stored.

## Fix

**Atomicity.** The insert loop now runs inside one transaction on a single connection, so a failed file commits nothing.

**Idempotency.** Migration 005 adds a unique index giving each ingested chunk an identity, and ingestion persists the `content_hash` and `source_file` it keys on. Re-inserting the same chunk of the same file is a no-op through `ON CONFLICT DO NOTHING`, whichever code path does the writing.

Both halves are worth having. The transaction is a runtime guarantee that holds as long as every write path opens one; the index is a schema-level invariant that holds regardless. Together they mean a failed file leaves nothing behind *and* a repeated write cannot duplicate.

### Why the identity is not just the content hash

A document can legitimately repeat a passage — a line restated in a changelog, the same phrase in two transcript turns. Keying on content alone treats the second copy as a duplicate and silently drops it, so an ordinary file would be stored incorrectly with no error. Verified against the markdown adapter: this eight-line file produces two chunks with the same hash.

```markdown
# v1.1

Fixed the connection pool bug.

# v1.0

Fixed the connection pool bug.
```

Including the chunk index keeps those distinct while still collapsing a genuine retry, which re-parses the file and produces the same chunk at the same position. The hash stays in the key so that editing a file and re-ingesting it is not silently ignored — changed content is a different identity and inserts normally.

### Migration 006

The index added in 004 assumed that a content hash in metadata meant the row came from `remember`. That held when only `remember` wrote one. Now that ingestion writes hashes too, the old predicate would reject any file containing a repeated passage — ingestion would fail outright. 006 scopes it to rows with no source file, which is the set it was always meant to cover. `remember` rows never carry one, so its dedup guarantee is unchanged.

### Extraction

`_run_extraction` moved outside the transaction. It is best-effort by design and swallows its own errors; running it inside would let a graph failure roll back a file that stored correctly.

### Existing rows

Untouched. Rows stored before this change have no content hash and stay exempt from the index. They were never at risk from a future retry, and backfilling a hash across every row would mean a full table rewrite on upgrade for no correctness gain.

## Tests

Five tests in `tests/test_ingest_atomicity.py`. Against the code before this change, three fail with the reported symptoms:

- `test_failed_file_leaves_no_partial_chunks` — `failed file left 2 chunk(s) behind`
- `test_retry_after_failure_produces_no_duplicates` — `assert 3 == 2`
- `test_reingesting_an_unchanged_file_is_a_no_op` — `assert 4 == 2`
- `test_repeated_passages_in_one_file_are_all_stored` — passes before and after; it guards against the data loss the naive fix would introduce
- `test_ingested_chunks_carry_identity_metadata` — pins the markers the guarantee depends on

253/253 pytest against a fresh database, `ruff check` and `ruff format --check` clean.

The tests stub the embedding model, which cannot be driven from several threads safely (#148).

Closes #115

Reported by @lcj-codex-coder.
