### PR TITLE
fix: serialize access to the shared embedding model

### DIFF
--- a/src/memory_vault/services/embedding.py
+++ b/src/memory_vault/services/embedding.py
@@ -6,6 +6,7 @@ Runs locally on CPU — no API calls, no data leaving the machine.
 """
 
 import logging
+import threading
 
 import numpy as np
 from sentence_transformers import SentenceTransformer
@@ -18,21 +19,43 @@ MODEL_NAME = settings.embedding_model
 
 _model: SentenceTransformer | None = None
 
+# Guards construction of the model. Held only while loading, so callers that
+# already have a model never queue behind a load.
+_load_lock = threading.Lock()
+
+# Held for the duration of every `encode` call. The model is a single shared
+# object and its forward pass is not safe to run from several threads at once —
+# doing so segfaults the interpreter rather than raising. Embedding runs in a
+# worker thread on the async paths, so concurrent requests reach it in parallel
+# and something has to serialize them.
+_encode_lock = threading.Lock()
+
 
 def _get_model() -> SentenceTransformer:
     """Load the model once, reuse on subsequent calls."""
     global _model
-    if _model is None:
-        logger.info("Loading embedding model: %s", settings.embedding_model)
-        _model = SentenceTransformer(settings.embedding_model)
-        logger.info("Model loaded — dimensions=%d", settings.embedding_dimensions)
-    return _model
+    # Fast path: no lock once the model exists, which is every call but the
+    # first. The assignment below is atomic, so a reader either sees None or a
+    # fully constructed model.
+    if _model is not None:
+        return _model
+
+    with _load_lock:
+        # Re-check under the lock: another thread may have loaded it while this
+        # one waited, and constructing a second model wastes minutes and memory.
+        if _model is None:
+            logger.info("Loading embedding model: %s", settings.embedding_model)
+            model = SentenceTransformer(settings.embedding_model)
+            logger.info("Model loaded — dimensions=%d", settings.embedding_dimensions)
+            _model = model
+        return _model
 
 
 def embed(text: str) -> list[float]:
     """Embed a single text string. Returns a list of floats (384-d)."""
     model = _get_model()
-    vector: np.ndarray = model.encode(text, normalize_embeddings=True)
+    with _encode_lock:
+        vector: np.ndarray = model.encode(text, normalize_embeddings=True)
     return vector.tolist()
 
 
@@ -45,10 +68,11 @@ def embed_batch(
         return []
     model = _get_model()
     bs = batch_size or settings.embedding_batch_size
-    vectors: np.ndarray = model.encode(
-        texts,
-        batch_size=bs,
-        normalize_embeddings=True,
-        show_progress_bar=len(texts) > bs,
-    )
+    with _encode_lock:
+        vectors: np.ndarray = model.encode(
+            texts,
+            batch_size=bs,
+            normalize_embeddings=True,
+            show_progress_bar=len(texts) > bs,
+        )
     return vectors.tolist()

--- a/tests/test_embedding_thread_safety.py
+++ b/tests/test_embedding_thread_safety.py
@@ -22,7 +22,7 @@ def test_parallel_encode_calls_do_not_crash():
     threads = 8
     start = threading.Barrier(threads)
     results: list[list[float]] = []
-    errors: list[BaseException] = []
+    errors: list[Exception] = []
     lock = threading.Lock()
 
     def worker(n: int) -> None:
@@ -31,7 +31,7 @@ def test_parallel_encode_calls_do_not_crash():
             vector = embedding.embed(f"concurrent embedding call number {n}")
             with lock:
                 results.append(vector)
-        except BaseException as exc:  # noqa: BLE001 - recorded and re-raised below
+        except Exception as exc:
             with lock:
                 errors.append(exc)
 
@@ -56,14 +56,14 @@ def test_parallel_batch_and_single_encode_mix():
     embedding._get_model()
 
     start = threading.Barrier(6)
-    errors: list[BaseException] = []
+    errors: list[Exception] = []
     lock = threading.Lock()
 
     def single(n: int) -> None:
         try:
             start.wait(timeout=60)
             embedding.embed(f"single {n}")
-        except BaseException as exc:  # noqa: BLE001
+        except Exception as exc:
             with lock:
                 errors.append(exc)
 
@@ -71,7 +71,7 @@ def test_parallel_batch_and_single_encode_mix():
         try:
             start.wait(timeout=60)
             embedding.embed_batch([f"batch {n} first", f"batch {n} second"])
-        except BaseException as exc:  # noqa: BLE001
+        except Exception as exc:
             with lock:
                 errors.append(exc)
 

--- a/tests/test_embedding_thread_safety.py
+++ b/tests/test_embedding_thread_safety.py
@@ -1,0 +1,135 @@
+"""The shared embedding model tolerates concurrent use."""
+
+import threading
+
+import pytest
+
+from memory_vault.services import embedding
+
+
+def test_parallel_encode_calls_do_not_crash():
+    """Many threads embedding at once complete without killing the process.
+
+    Regression guard for #148. The model is a single shared object and its
+    forward pass is not safe to run from several threads simultaneously — the
+    failure mode is a segfault, not an exception, so an unguarded version takes
+    the interpreter down instead of failing this assertion. Embedding runs in a
+    worker thread on the async paths, which is how ordinary concurrent requests
+    reach it in parallel.
+    """
+    embedding._get_model()  # Load once up front so this measures encode, not load.
+
+    threads = 8
+    start = threading.Barrier(threads)
+    results: list[list[float]] = []
+    errors: list[BaseException] = []
+    lock = threading.Lock()
+
+    def worker(n: int) -> None:
+        try:
+            start.wait(timeout=60)
+            vector = embedding.embed(f"concurrent embedding call number {n}")
+            with lock:
+                results.append(vector)
+        except BaseException as exc:  # noqa: BLE001 - recorded and re-raised below
+            with lock:
+                errors.append(exc)
+
+    workers = [threading.Thread(target=worker, args=(i,)) for i in range(threads)]
+    for t in workers:
+        t.start()
+    for t in workers:
+        t.join(timeout=120)
+
+    assert not [t for t in workers if t.is_alive()], "an embedding thread hung"
+    assert errors == [], f"concurrent embedding raised: {errors}"
+    assert len(results) == threads
+    assert all(len(v) == embedding.settings.embedding_dimensions for v in results)
+
+
+def test_parallel_batch_and_single_encode_mix():
+    """`embed` and `embed_batch` running together stay safe.
+
+    Both reach the same shared model, so the guarantee has to cover them
+    jointly rather than one at a time.
+    """
+    embedding._get_model()
+
+    start = threading.Barrier(6)
+    errors: list[BaseException] = []
+    lock = threading.Lock()
+
+    def single(n: int) -> None:
+        try:
+            start.wait(timeout=60)
+            embedding.embed(f"single {n}")
+        except BaseException as exc:  # noqa: BLE001
+            with lock:
+                errors.append(exc)
+
+    def batch(n: int) -> None:
+        try:
+            start.wait(timeout=60)
+            embedding.embed_batch([f"batch {n} first", f"batch {n} second"])
+        except BaseException as exc:  # noqa: BLE001
+            with lock:
+                errors.append(exc)
+
+    workers = [threading.Thread(target=single, args=(i,)) for i in range(3)]
+    workers += [threading.Thread(target=batch, args=(i,)) for i in range(3)]
+    for t in workers:
+        t.start()
+    for t in workers:
+        t.join(timeout=120)
+
+    assert not [t for t in workers if t.is_alive()], "an embedding thread hung"
+    assert errors == [], f"mixed concurrent embedding raised: {errors}"
+
+
+def test_concurrent_first_use_loads_one_model(monkeypatch):
+    """A cold start under load constructs the model exactly once.
+
+    The lazy load used to check and assign without a lock, so several threads
+    arriving before the first load finished would each build their own
+    SentenceTransformer. That wastes the load time and memory of every extra
+    copy, and leaves whichever instance loses the assignment to be collected
+    while callers may still be using it.
+    """
+    monkeypatch.setattr(embedding, "_model", None)
+
+    constructed: list[str] = []
+    real_ctor = embedding.SentenceTransformer
+
+    def counting_ctor(*args, **kwargs):
+        constructed.append(args[0] if args else "")
+        return real_ctor(*args, **kwargs)
+
+    monkeypatch.setattr(embedding, "SentenceTransformer", counting_ctor)
+
+    threads = 6
+    start = threading.Barrier(threads)
+    models: list[object] = []
+    lock = threading.Lock()
+
+    def worker() -> None:
+        start.wait(timeout=60)
+        model = embedding._get_model()
+        with lock:
+            models.append(model)
+
+    workers = [threading.Thread(target=worker) for _ in range(threads)]
+    for t in workers:
+        t.start()
+    for t in workers:
+        t.join(timeout=180)
+
+    assert len(constructed) == 1, f"model was constructed {len(constructed)} times"
+    assert len(models) == threads
+    assert all(m is models[0] for m in models), "callers received different model objects"
+
+
+@pytest.mark.parametrize("texts", [[], ["only one"]])
+def test_embed_batch_edge_cases_still_work(texts):
+    """Locking did not change the empty-input shortcut or ordinary batching."""
+    result = embedding.embed_batch(texts)
+    assert len(result) == len(texts)


### PR DESCRIPTION
## Problem

`embed()` and `embed_batch()` share one module-level `SentenceTransformer` and called `encode` on it with no serialization. Embedding runs through `asyncio.to_thread` on the async paths, so two ordinary concurrent requests — two `remember` calls, two searches — reach the model in parallel.

Its forward pass is not safe to run that way. The failure is an abort, not an exception:

```
Fatal Python error: Segmentation fault

Thread 0x0000000171907000 (most recent call first):
  File ".../transformers/masking_utils.py", line 831 in _preprocess_mask_arguments
  File ".../sentence_transformers/sentence_transformer/model.py", line 662 in encode
  File ".../memory_vault/services/embedding.py", line 35 in embed

Current thread 0x00000001708fb000 (most recent call first):
  ...same stack...
```

The lazy load had a second, quieter race: `_get_model` checked `_model is None` and assigned without a lock, so several threads arriving before the first load finished each constructed their own model.

## Fix

`encode` runs under a lock in both `embed` and `embed_batch`. This serializes embedding, which is what a single shared instance already implied — the previous behaviour was not faster, only unsafe.

The load runs under a separate lock with a double check. The fast path stays lock-free once the model exists, so callers never queue behind a load that already finished, and the two locks are independent so embedding does not block on loading or vice versa.

## Tests

Five tests in `tests/test_embedding_thread_safety.py`, driving the real model rather than a stub — a stubbed model cannot reproduce the crash.

- `test_parallel_encode_calls_do_not_crash` — 8 threads released from a barrier into `embed`
- `test_parallel_batch_and_single_encode_mix` — `embed` and `embed_batch` interleaved, since both reach the same object
- `test_concurrent_first_use_loads_one_model` — 6 threads racing a cold start construct exactly one model and all receive the same instance
- `test_embed_batch_edge_cases_still_work` — the empty-input shortcut and ordinary batching are unchanged

Against the code before this change the first test does not fail — it aborts the interpreter, exit code 134:

```
tests/test_embedding_thread_safety.py::test_parallel_encode_calls_do_not_crash Fatal Python error: Aborted
EXIT=134
```

Worth knowing when reading CI: an unguarded regression here surfaces as the test process dying, which looks like infrastructure flakiness rather than a failed assertion.

258/258 pytest, `ruff check` and `ruff format --check` clean.

## Trade-off

Embedding is now serialized across threads, so concurrent embed-heavy work queues rather than running in parallel. That is a real throughput ceiling, and the honest framing is that the parallelism it replaces never worked — it crashed. If parallel embedding throughput matters later, the shape would be a small pool of model instances rather than removing the lock.

Closes #148
