### PR TITLE
fix: keep partial think tags across streaming chunks

### DIFF
--- a/src/memory_vault/api/routers/chat.py
+++ b/src/memory_vault/api/routers/chat.py
@@ -64,6 +64,21 @@ def _estimate_tokens(text: str) -> int:
 # ---------------------------------------------------------------------------
 
 
+def _partial_tag_suffix(text: str, tag: str) -> str:
+    """Return the trailing part of `text` that could begin `tag`.
+
+    A streamed response can split a tag across two chunks, so a buffer ending
+    in "</thi" has to be carried forward rather than dropped: the "nk>" that
+    completes it arrives next. Returns "" when no suffix of `text` is a prefix
+    of `tag`, which is the common case and keeps nothing needlessly.
+    """
+    max_len = min(len(text), len(tag) - 1)
+    for length in range(max_len, 0, -1):
+        if tag.startswith(text[-length:]):
+            return text[-length:]
+    return ""
+
+
 def _strip_thinking(text: str) -> str:
     """Strip chain-of-thought from non-streamed LLM output.
 
@@ -445,12 +460,13 @@ async def _stream_openai_compat(
                 if not in_think:
                     open_idx = buffer.find("<think>")
                     if open_idx == -1:
-                        # Hold back the tail in case it's a partial "<think>"
-                        if "<" in buffer[-7:]:
-                            tail = buffer[-7:]
-                            emit, buffer = buffer[:-7], tail
-                        else:
-                            emit, buffer = buffer, ""
+                        # Hold back only a tail that could begin "<think>".
+                        # The previous check kept up to seven characters
+                        # whenever the tail contained any "<", which delayed
+                        # ordinary text like "a < b" for no reason.
+                        tail = _partial_tag_suffix(buffer, "<think>")
+                        emit = buffer[: len(buffer) - len(tail)] if tail else buffer
+                        buffer = tail
                         if emit:
                             yield emit
                         break
@@ -463,7 +479,13 @@ async def _stream_openai_compat(
                 else:
                     close_idx = buffer.find("</think>")
                     if close_idx == -1:
-                        buffer = ""  # discard thinking content
+                        # Discard the reasoning, but keep any tail that could be
+                        # the start of a "</think>" split across two chunks.
+                        # Clearing the whole buffer here dropped the "</thi" of
+                        # a "</thi" + "nk>ANSWER" pair, so the closing tag was
+                        # never recognised and the answer was filtered away
+                        # along with the reasoning.
+                        buffer = _partial_tag_suffix(buffer, "</think>")
                         break
                     buffer = buffer[close_idx + len("</think>") :].lstrip()
                     in_think = False

--- a/tests/test_chat_think_tag_boundary.py
+++ b/tests/test_chat_think_tag_boundary.py
@@ -1,0 +1,131 @@
+"""Thinking-block filtering survives tags split across stream chunks."""
+
+import json
+
+import pytest
+
+from memory_vault.api.routers import chat
+
+# Applied per-test rather than module-wide: the helper test below is synchronous
+# and a module-level mark would flag it as a mismarked async test.
+asyncio_test = pytest.mark.asyncio
+
+
+class _FakeStream:
+    """Minimal stand-in for httpx's streaming response context manager."""
+
+    def __init__(self, pieces: list[str]):
+        self._pieces = pieces
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc_info):
+        return False
+
+    def raise_for_status(self) -> None:
+        return None
+
+    async def aiter_lines(self):
+        for piece in self._pieces:
+            payload = {"choices": [{"delta": {"content": piece}}]}
+            yield f"data: {json.dumps(payload)}"
+        yield "data: [DONE]"
+
+
+class _FakeClient:
+    def __init__(self, pieces: list[str]):
+        self._pieces = pieces
+
+    def stream(self, *args, **kwargs):
+        return _FakeStream(self._pieces)
+
+
+async def _collect(pieces: list[str]) -> str:
+    client = _FakeClient(pieces)
+    out = [
+        chunk
+        async for chunk in chat._stream_openai_compat(client, "http://x", {}, {"messages": []})
+    ]
+    return "".join(out)
+
+
+@asyncio_test
+async def test_closing_tag_split_across_chunks_keeps_the_answer():
+    """The reported case: "</thi" + "nk>ANSWER" must still yield the answer.
+
+    Regression guard for #98. While inside a thinking block the parser cleared
+    the whole buffer whenever no complete "</think>" was present, discarding a
+    trailing "</thi" that the next chunk would have completed. The closing tag
+    was then never recognised and the answer was filtered away as reasoning.
+    """
+    assert await _collect(["<think>secret</thi", "nk>ANSWER"]) == "ANSWER"
+
+
+@pytest.mark.parametrize("split_at", range(1, len("</think>")))
+@asyncio_test
+async def test_closing_tag_split_at_every_position(split_at: int):
+    """The answer survives a split at any point inside the closing tag."""
+    tag = "</think>"
+    pieces = ["<think>reasoning" + tag[:split_at], tag[split_at:] + "ANSWER"]
+    assert await _collect(pieces) == "ANSWER"
+
+
+@pytest.mark.parametrize("split_at", range(1, len("<think>")))
+@asyncio_test
+async def test_opening_tag_split_at_every_position(split_at: int):
+    """A split opening tag still suppresses the reasoning that follows it."""
+    tag = "<think>"
+    pieces = [tag[:split_at], tag[split_at:] + "reasoning</think>ANSWER"]
+    assert await _collect(pieces) == "ANSWER"
+
+
+@asyncio_test
+async def test_unsplit_stream_is_unchanged():
+    """The ordinary single-chunk case keeps working."""
+    assert await _collect(["<think>reasoning</think>ANSWER"]) == "ANSWER"
+
+
+@asyncio_test
+async def test_text_without_thinking_passes_through():
+    assert await _collect(["plain ", "answer"]) == "plain answer"
+
+
+@asyncio_test
+async def test_angle_bracket_near_the_end_is_not_swallowed():
+    """A trailing "<" that cannot begin a think tag still reaches the reader.
+
+    The buffer used to hold back its last seven characters whenever they
+    contained any "<". At the end of a stream nothing arrives to flush that
+    tail, so a chunk ending in something like "a < b" lost those characters
+    entirely rather than merely delaying them.
+    """
+    assert await _collect(["result: a < b"]) == "result: a < b"
+
+
+@asyncio_test
+async def test_angle_bracket_mid_stream_passes_through():
+    assert await _collect(["if a < b then", " done"]) == "if a < b then done"
+
+
+@asyncio_test
+async def test_reasoning_never_leaks_when_stream_ends_mid_block():
+    """A stream that ends inside a thinking block emits nothing from it."""
+    assert await _collect(["<think>secret reasoning"]) == ""
+
+
+@asyncio_test
+async def test_partial_closing_tag_at_stream_end_is_not_emitted():
+    """A dangling "</thi" is reasoning, not answer text, so it stays hidden."""
+    assert await _collect(["<think>secret</thi"]) == ""
+
+
+def test_partial_tag_suffix_matches_only_real_prefixes():
+    """The helper keeps a tail only when it could actually begin the tag."""
+    assert chat._partial_tag_suffix("reasoning</thi", "</think>") == "</thi"
+    assert chat._partial_tag_suffix("reasoning<", "</think>") == "<"
+    assert chat._partial_tag_suffix("reasoning", "</think>") == ""
+    assert chat._partial_tag_suffix("a < b", "</think>") == ""
+    # A complete tag is the caller's business to find; the helper holds only
+    # strict prefixes, never the whole tag.
+    assert chat._partial_tag_suffix("x</think>", "</think>") == ""


### PR DESCRIPTION
## Problem

Inside a thinking block, the streaming filter cleared its entire buffer whenever a complete `</think>` was not present:

```python
close_idx = buffer.find("</think>")
if close_idx == -1:
    buffer = ""   # discards a trailing "</thi" too
    break
```

So the reported split lost the answer:

```python
["<think>secret</thi", "nk>ANSWER"]   # emitted "" instead of "ANSWER"
```

The `</thi` was thrown away, the following `nk>ANSWER` no longer completed a tag, the parser stayed inside the block, and the answer was filtered out as reasoning.

## Fix

Both tag searches now keep only the trailing text that could begin the tag they are looking for, through one shared helper:

```python
def _partial_tag_suffix(text: str, tag: str) -> str:
    max_len = min(len(text), len(tag) - 1)
    for length in range(max_len, 0, -1):
        if tag.startswith(text[-length:]):
            return text[-length:]
    return ""
```

A buffer ending in `</thi` is carried into the next chunk; one ending in `reasoning` keeps nothing.

### A second bug in the opening-tag path

The same helper replaces the opening-tag check, which held back the last seven characters whenever they contained any `<`:

```python
if "<" in buffer[-7:]:
    emit, buffer = buffer[:-7], buffer[-7:]
```

That is too broad — ordinary text like `a < b` was withheld — and at the end of a stream it is lossy, because nothing arrives to flush the tail. A response ending in `result: a < b` emitted only `result`, silently dropping the rest. This was not in the original report; it surfaced while writing the tests for the reported bug.

## Tests

21 tests in `tests/test_chat_think_tag_boundary.py`, driving `_stream_openai_compat` through a fake streaming client — no database or model server needed, matching the reproduction in the report.

Against the code before this change:

- `test_closing_tag_split_across_chunks_keeps_the_answer` — `assert '' == 'ANSWER'`
- `test_closing_tag_split_at_every_position` — the same failure at all 8 split points inside `</think>`
- `test_angle_bracket_near_the_end_is_not_swallowed` — `assert 'result' == 'result: a < b'`

The remaining tests pass both before and after; they pin behaviour that must not change — reasoning stays hidden, a stream ending mid-block emits nothing, a dangling `</thi` is not mistaken for answer text.

279/279 pytest, `ruff check` and `ruff format --check` clean.

Closes #98

Reported by @lcj-codex-coder.
