### PR TITLE
feat: create a memory space on its first write

### DIFF
--- a/src/memory_vault/api/routers/ingest.py
+++ b/src/memory_vault/api/routers/ingest.py
@@ -10,8 +10,8 @@ from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile, s
 
 from memory_vault.api.deps import require_token
 from memory_vault.api.schemas import IngestResponse, IngestTextRequest
-from memory_vault.models.db import fetch_one
 from memory_vault.services.ingestion import IngestionPipeline, ingest_text
+from memory_vault.services.spaces import InvalidSpaceName, ensure_space
 
 logger = logging.getLogger(__name__)
 
@@ -25,13 +25,17 @@ _UPLOAD_CHUNK = 1024 * 1024  # 1 MB streaming reads
 
 
 async def _resolve_space_id(name: str) -> int:
-    row = await fetch_one("SELECT id FROM memory_spaces WHERE name = %s", (name,))
-    if not row:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Unknown space: {name}",
-        )
-    return int(row["id"])
+    """Return the space's id, creating it on first write.
+
+    Ingesting into a space that does not exist yet used to 404, which meant a
+    caller had to create the space in a separate request before its first
+    write. The name still has to be one the API would accept from an explicit
+    create, so a typo cannot quietly produce a junk space with any spelling.
+    """
+    try:
+        return await ensure_space(name)
+    except InvalidSpaceName as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
 
 
 @router.post("/ingest/text", response_model=IngestResponse)

--- a/src/memory_vault/api/routers/spaces.py
+++ b/src/memory_vault/api/routers/spaces.py
@@ -7,22 +7,11 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from memory_vault.api.deps import require_token
 from memory_vault.api.schemas import SpaceCreateRequest, SpaceInfo, SpaceList
 from memory_vault.models.db import execute_query, fetch_all, fetch_one
+from memory_vault.services.spaces import RESERVED_SPACE_NAMES
 
 router = APIRouter(prefix="/api", tags=["spaces"], dependencies=[Depends(require_token)])
 
-# Names reserved for internal/future use. `default` is also reserved at the
-# database level (seeded migration) and would 409 on conflict, but listing it
-# here gives a clearer error before we hit the DB.
-RESERVED_SPACE_NAMES: frozenset[str] = frozenset(
-    {
-        "default",
-        "system",
-        "admin",
-        "all",
-        "none",
-        "_internal",
-    }
-)
+__all__ = ["RESERVED_SPACE_NAMES", "router"]
 
 
 @router.get("/spaces", response_model=SpaceList)

--- a/src/memory_vault/services/spaces.py
+++ b/src/memory_vault/services/spaces.py
@@ -59,6 +59,17 @@ def validate_space_name(name: str) -> None:
         )
 
 
+def _sanitized_for_log(name: str) -> str:
+    """Return `name` reduced to characters a space name may contain.
+
+    Callers reach the log only after validate_space_name has accepted the
+    name, so in practice this returns it unchanged. It exists so that the
+    guarantee holds at the log call itself rather than depending on a check
+    several lines earlier that a later edit could reorder.
+    """
+    return "".join(c for c in name if c.isalnum() or c == "-")[:SPACE_NAME_MAX_LENGTH]
+
+
 async def get_space_id(name: str) -> int | None:
     """Return the id of an existing space, or None."""
     row = await fetch_one("SELECT id FROM memory_spaces WHERE name = %s", (name,))
@@ -86,7 +97,12 @@ async def ensure_space(name: str) -> int:
         (name,),
     )
     if row is not None:
-        logger.info("Created space on first write: %s", name)
+        # Log a value re-derived from the pattern rather than the caller's
+        # string. validate_space_name has already rejected anything carrying a
+        # newline or control character, so this cannot change what is written;
+        # it makes the sanitisation visible at the point of use, to readers and
+        # to static analysis alike.
+        logger.info("Created space on first write: %s", _sanitized_for_log(name))
         return int(row["id"])
 
     # The conflict fired: another caller created it between our read and our

--- a/src/memory_vault/services/spaces.py
+++ b/src/memory_vault/services/spaces.py
@@ -19,6 +19,11 @@ logger = logging.getLogger(__name__)
 SPACE_NAME_PATTERN = re.compile(r"^[a-z0-9][a-z0-9-]*$")
 SPACE_NAME_MAX_LENGTH = 64
 
+# Everything a space name may not contain. Applied before a name is written to
+# a log, so a value that somehow bypassed validation still cannot introduce a
+# line break and forge an entry.
+_LOG_UNSAFE_CHARS = re.compile(r"[^a-z0-9-]")
+
 # Names reserved for internal/future use. `default` is also reserved at the
 # database level (seeded migration) and would 409 on conflict, but listing it
 # here gives a clearer error before we hit the DB.
@@ -66,8 +71,12 @@ def _sanitized_for_log(name: str) -> str:
     name, so in practice this returns it unchanged. It exists so that the
     guarantee holds at the log call itself rather than depending on a check
     several lines earlier that a later edit could reorder.
+
+    Uses an explicit character class rather than `str.isalnum`, which accepts
+    letters from any script and so would pass through more than a space name
+    may contain.
     """
-    return "".join(c for c in name if c.isalnum() or c == "-")[:SPACE_NAME_MAX_LENGTH]
+    return _LOG_UNSAFE_CHARS.sub("", name)[:SPACE_NAME_MAX_LENGTH]
 
 
 async def get_space_id(name: str) -> int | None:

--- a/src/memory_vault/services/spaces.py
+++ b/src/memory_vault/services/spaces.py
@@ -65,18 +65,22 @@ def validate_space_name(name: str) -> None:
 
 
 def _sanitized_for_log(name: str) -> str:
-    """Return `name` reduced to characters a space name may contain.
+    """Return `name` in a form that is safe to emit in a log line.
 
     Callers reach the log only after validate_space_name has accepted the
     name, so in practice this returns it unchanged. It exists so that the
     guarantee holds at the log call itself rather than depending on a check
     several lines earlier that a later edit could reorder.
 
-    Uses an explicit character class rather than `str.isalnum`, which accepts
-    letters from any script and so would pass through more than a space name
-    may contain.
+    Line breaks are removed explicitly before the character class is applied.
+    The class would drop them anyway, so the output is the same either way,
+    but log forging is what this function exists to prevent and it is worth
+    stating in the code rather than leaving as a consequence of the pattern.
+    An explicit class is used rather than `str.isalnum`, which is true for
+    letters in any script and would pass through more than a name may hold.
     """
-    return _LOG_UNSAFE_CHARS.sub("", name)[:SPACE_NAME_MAX_LENGTH]
+    no_line_breaks = name.replace("\r", "").replace("\n", "")
+    return _LOG_UNSAFE_CHARS.sub("", no_line_breaks)[:SPACE_NAME_MAX_LENGTH]
 
 
 async def get_space_id(name: str) -> int | None:

--- a/src/memory_vault/services/spaces.py
+++ b/src/memory_vault/services/spaces.py
@@ -1,0 +1,97 @@
+"""Memory space resolution and on-demand creation.
+
+Shared by the routers that need a space id, so the rules about which names
+are legal live in one place rather than being restated at each call site.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+
+from memory_vault.models.db import execute_returning, fetch_one
+
+logger = logging.getLogger(__name__)
+
+# Mirrors the constraint on SpaceCreateRequest.name. Kept as a compiled pattern
+# here because auto-creation happens below the request-schema layer, where
+# pydantic has already validated the explicit-create path but not this one.
+SPACE_NAME_PATTERN = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+SPACE_NAME_MAX_LENGTH = 64
+
+# Names reserved for internal/future use. `default` is also reserved at the
+# database level (seeded migration) and would 409 on conflict, but listing it
+# here gives a clearer error before we hit the DB.
+RESERVED_SPACE_NAMES: frozenset[str] = frozenset(
+    {
+        "default",
+        "system",
+        "admin",
+        "all",
+        "none",
+        "_internal",
+    }
+)
+
+
+class InvalidSpaceName(ValueError):
+    """A space name that may not be created."""
+
+
+def validate_space_name(name: str) -> None:
+    """Raise InvalidSpaceName unless `name` may be created.
+
+    Applies the same rules as the explicit create endpoint, so a name the API
+    would refuse cannot slip in through a path that creates spaces on demand.
+    """
+    if not name:
+        raise InvalidSpaceName("Space name must not be empty.")
+    if len(name) > SPACE_NAME_MAX_LENGTH:
+        raise InvalidSpaceName(
+            f"Space name exceeds {SPACE_NAME_MAX_LENGTH} characters: {name[:80]}"
+        )
+    if name in RESERVED_SPACE_NAMES:
+        raise InvalidSpaceName(f"Space name is reserved: {name}")
+    if not SPACE_NAME_PATTERN.match(name):
+        raise InvalidSpaceName(
+            "Space name must use lowercase letters, digits, and hyphens, "
+            f"and start with a letter or digit: {name}"
+        )
+
+
+async def get_space_id(name: str) -> int | None:
+    """Return the id of an existing space, or None."""
+    row = await fetch_one("SELECT id FROM memory_spaces WHERE name = %s", (name,))
+    return int(row["id"]) if row else None
+
+
+async def ensure_space(name: str) -> int:
+    """Return the id of `name`, creating the space if it does not exist.
+
+    Raises InvalidSpaceName when the name may not be created. Two callers
+    racing on the same new name is expected — the unique constraint on
+    memory_spaces.name settles it and the loser reads back the winner's row,
+    so both get the same id rather than one seeing an integrity error.
+    """
+    existing = await get_space_id(name)
+    if existing is not None:
+        return existing
+
+    validate_space_name(name)
+
+    row = await execute_returning(
+        """INSERT INTO memory_spaces (name) VALUES (%s)
+           ON CONFLICT (name) DO NOTHING
+           RETURNING id""",
+        (name,),
+    )
+    if row is not None:
+        logger.info("Created space on first write: %s", name)
+        return int(row["id"])
+
+    # The conflict fired: another caller created it between our read and our
+    # insert. Its row is committed, so this read finds it.
+    created_by_other = await get_space_id(name)
+    if created_by_other is None:
+        raise InvalidSpaceName(f"Space could not be created: {name}")
+    return created_by_other

--- a/tests/test_api_routers.py
+++ b/tests/test_api_routers.py
@@ -168,13 +168,19 @@ class TestIngestText:
         assert body["chunk_id"]
         assert body["chunks_created"] == 1
 
-    async def test_ingest_unknown_space_returns_404(self, client, auth_headers):
+    async def test_ingest_invalid_space_name_returns_400(self, client, auth_headers):
+        """An unusable name is refused rather than created.
+
+        Ingesting into a space that does not exist yet now creates it, so the
+        remaining failure case is a name the API would never accept — here an
+        underscore, which the space-name rules exclude.
+        """
         r = await client.post(
             "/api/ingest/text",
             headers=auth_headers,
             json={"text": "hello", "space": "no_such_space"},
         )
-        assert r.status_code == 404
+        assert r.status_code == 400
 
     async def test_ingest_empty_text_rejected(self, client, auth_headers):
         r = await client.post(
@@ -214,11 +220,12 @@ class TestIngestFile:
         assert body["stored"] is True
         assert body["chunks_created"] >= 1
 
-    async def test_upload_to_unknown_space(self, client, auth_headers):
+    async def test_upload_to_invalid_space_name_returns_400(self, client, auth_headers):
+        """Uploads follow the same rule as text ingestion."""
         files = {"file": ("test.txt", io.BytesIO(b"hello"), "text/plain")}
         data = {"space": "no_such_space"}
         r = await client.post("/api/ingest/file", headers=auth_headers, files=files, data=data)
-        assert r.status_code == 404
+        assert r.status_code == 400
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ensure_space.py
+++ b/tests/test_ensure_space.py
@@ -154,6 +154,23 @@ async def test_sanitized_for_log_strips_line_breaks_and_control_characters():
     assert "\r" not in spaces._sanitized_for_log("evil\r\nINFO fake entry")
     assert len(spaces._sanitized_for_log("x" * 500)) <= spaces.SPACE_NAME_MAX_LENGTH
 
+    # Only the characters a space name may hold survive — letters from other
+    # scripts and uppercase are dropped rather than passed through, which a
+    # str.isalnum() filter would not do.
+    assert spaces._sanitized_for_log("wörk") == "wrk"
+    assert spaces._sanitized_for_log("Кириллица") == ""
+    assert spaces._sanitized_for_log("UPPER") == ""
+    assert spaces._sanitized_for_log("tab\there") == "tabhere"
+
+    # The property that matters for logging: nothing that could break a log
+    # line or forge an entry survives, whatever goes in. The result is not
+    # necessarily a *valid* space name — "-x" stays "-x" — but it is always
+    # free of line breaks and control characters, and bounded in length.
+    for probe in ("evil\nfake", "wörk", "a b c", "x" * 500, "-leading", "---", "\x00\x1b[31m"):
+        cleaned = spaces._sanitized_for_log(probe)
+        assert not any(c in cleaned for c in "\r\n\t\x00\x1b")
+        assert len(cleaned) <= spaces.SPACE_NAME_MAX_LENGTH
+
 
 class TestIngestAutoCreatesSpace:
     """The REST ingest surface creates the space on first write."""

--- a/tests/test_ensure_space.py
+++ b/tests/test_ensure_space.py
@@ -141,6 +141,20 @@ async def test_ensure_space_resolves_the_seeded_default_space():
     assert space_id > 0
 
 
+async def test_sanitized_for_log_strips_line_breaks_and_control_characters():
+    """Nothing that could forge a log line survives the log-sanitiser.
+
+    Names are validated before they reach the log, so this is a second line
+    of defence rather than the only one — but it is the one that holds if the
+    validation and the logging ever drift apart.
+    """
+    assert spaces._sanitized_for_log("work") == "work"
+    assert spaces._sanitized_for_log("side-projects") == "side-projects"
+    assert "\n" not in spaces._sanitized_for_log("evil\nINFO fake entry")
+    assert "\r" not in spaces._sanitized_for_log("evil\r\nINFO fake entry")
+    assert len(spaces._sanitized_for_log("x" * 500)) <= spaces.SPACE_NAME_MAX_LENGTH
+
+
 class TestIngestAutoCreatesSpace:
     """The REST ingest surface creates the space on first write."""
 

--- a/tests/test_ensure_space.py
+++ b/tests/test_ensure_space.py
@@ -1,0 +1,197 @@
+"""Spaces are created on first write, with the same name rules as elsewhere."""
+
+import asyncio
+import json
+
+import pytest
+import pytest_asyncio
+
+from memory_vault.mcp import server as mcp_server
+from memory_vault.models.db import execute_query, fetch_all, fetch_one
+from memory_vault.services import spaces
+
+pytestmark = pytest.mark.asyncio
+
+# Every space name this module creates. The shared table-cleaning fixture
+# truncates chunks but leaves memory_spaces alone, so these are removed here —
+# otherwise a second run would find them already present and the
+# "did not exist beforehand" assertions would be meaningless.
+_SPACE_NAMES = (
+    "brand-new",
+    "reused",
+    "made-explicitly",
+    "raced",
+    "auto-made",
+    "never-created-by-mcp",
+)
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _clean_spaces():
+    async def remove() -> None:
+        # Chunks reference the space, so they go first — a test that ingested
+        # into an auto-created space leaves rows behind that would otherwise
+        # block the delete with a foreign-key violation.
+        await execute_query(
+            """DELETE FROM chunks WHERE space_id IN (
+                   SELECT id FROM memory_spaces WHERE name = ANY(%s))""",
+            (list(_SPACE_NAMES),),
+            commit=True,
+        )
+        await execute_query(
+            "DELETE FROM memory_spaces WHERE name = ANY(%s)",
+            (list(_SPACE_NAMES),),
+            commit=True,
+        )
+
+    await remove()
+    yield
+    await remove()
+
+
+async def _space_exists(name: str) -> bool:
+    row = await fetch_one("SELECT 1 FROM memory_spaces WHERE name = %s", (name,))
+    return row is not None
+
+
+async def test_ensure_space_creates_a_missing_space():
+    assert not await _space_exists("brand-new")
+
+    space_id = await spaces.ensure_space("brand-new")
+
+    assert space_id > 0
+    assert await _space_exists("brand-new")
+
+
+async def test_ensure_space_returns_the_existing_id():
+    """An existing space is reused, not duplicated."""
+    first = await spaces.ensure_space("reused")
+    second = await spaces.ensure_space("reused")
+
+    assert first == second
+    rows = await fetch_all("SELECT id FROM memory_spaces WHERE name = %s", ("reused",))
+    assert len(rows) == 1
+
+
+async def test_ensure_space_reuses_a_space_created_the_explicit_way():
+    await execute_query(
+        "INSERT INTO memory_spaces (name, description) VALUES (%s, %s)",
+        ("made-explicitly", "created up front"),
+        commit=True,
+    )
+
+    space_id = await spaces.ensure_space("made-explicitly")
+
+    row = await fetch_one(
+        "SELECT id, description FROM memory_spaces WHERE name = %s", ("made-explicitly",)
+    )
+    assert space_id == int(row["id"])
+    assert row["description"] == "created up front", "existing space was overwritten"
+
+
+async def test_concurrent_ensure_space_creates_one_space():
+    """Two writers racing on the same new name agree on one space.
+
+    The unique constraint on the name settles the race; the caller that loses
+    reads back the winner's row rather than surfacing an integrity error.
+    """
+    results = await asyncio.gather(
+        spaces.ensure_space("raced"),
+        spaces.ensure_space("raced"),
+        spaces.ensure_space("raced"),
+    )
+
+    assert len(set(results)) == 1, f"callers disagreed about the space id: {results}"
+    rows = await fetch_all("SELECT id FROM memory_spaces WHERE name = %s", ("raced",))
+    assert len(rows) == 1
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "Has-Capitals",
+        "has_underscore",
+        "-leading-hyphen",
+        "has space",
+        "has.dot",
+        "",
+        "x" * 65,
+    ],
+)
+async def test_ensure_space_rejects_names_the_api_would_refuse(name: str):
+    """Auto-creation applies the rules the explicit create endpoint applies."""
+    with pytest.raises(spaces.InvalidSpaceName):
+        await spaces.ensure_space(name)
+
+    if name:
+        assert not await _space_exists(name)
+
+
+@pytest.mark.parametrize("name", sorted(spaces.RESERVED_SPACE_NAMES - {"default"}))
+async def test_ensure_space_rejects_reserved_names(name: str):
+    with pytest.raises(spaces.InvalidSpaceName):
+        await spaces.ensure_space(name)
+
+    assert not await _space_exists(name)
+
+
+async def test_ensure_space_resolves_the_seeded_default_space():
+    """`default` is reserved for creation but exists, so writes to it resolve."""
+    space_id = await spaces.ensure_space("default")
+    assert space_id > 0
+
+
+class TestIngestAutoCreatesSpace:
+    """The REST ingest surface creates the space on first write."""
+
+    async def test_ingest_text_into_a_new_space_succeeds(self, client, auth_headers):
+        assert not await _space_exists("auto-made")
+
+        resp = await client.post(
+            "/api/ingest/text",
+            headers=auth_headers,
+            json={"text": "first memory in a new space", "space": "auto-made"},
+        )
+
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["stored"] is True
+        assert await _space_exists("auto-made")
+
+    async def test_ingest_text_rejects_an_invalid_space_name(self, client, auth_headers):
+        resp = await client.post(
+            "/api/ingest/text",
+            headers=auth_headers,
+            json={"text": "should not be stored", "space": "Bad Name"},
+        )
+
+        assert resp.status_code == 400, resp.text
+        assert not await _space_exists("Bad Name")
+
+    async def test_ingest_text_rejects_a_reserved_space_name(self, client, auth_headers):
+        resp = await client.post(
+            "/api/ingest/text",
+            headers=auth_headers,
+            json={"text": "should not be stored", "space": "admin"},
+        )
+
+        assert resp.status_code == 400, resp.text
+        assert "reserved" in resp.json()["detail"].lower()
+        assert not await _space_exists("admin")
+
+
+class TestMcpRememberStillRefusesUnknownSpaces:
+    """MCP keeps rejecting unknown spaces rather than creating them.
+
+    Auto-creation is deliberately confined to the REST surface. A space name
+    reaching `remember` comes from a model reading a prompt, where a typo
+    would otherwise create a plausible-looking space that quietly splits a
+    user's memories in two.
+    """
+
+    async def test_remember_into_a_missing_space_does_not_create_it(self):
+        raw = await mcp_server.remember("some memory", space="never-created-by-mcp")
+        result = json.loads(raw)
+
+        assert result["stored"] is False
+        assert "Unknown space" in result["error"]
+        assert not await _space_exists("never-created-by-mcp")


### PR DESCRIPTION
## Problem

Storing into a space that did not exist yet returned 404:

```
POST /api/ingest/text {"text": "...", "space": "reading-notes"}
-> 404 {"detail": "Unknown space: reading-notes"}
```

So a caller had to make a separate `POST /api/spaces` request before the first write to any new space.

## Change

The REST ingest endpoints create the space on demand. The name still has to be one the API would accept from an explicit create — lowercase letters, digits and hyphens, at most 64 characters, and not a reserved name — so a typo fails with a 400 rather than quietly producing a plausible-looking space that splits memories between two spellings.

Those rules and the reserved-name list moved into a new `services/spaces.py`, which `POST /api/spaces` now imports. Previously the reserved list lived in the router; keeping one copy means the two paths cannot drift into disagreeing about which names are legal.

Racing callers are settled by the unique constraint on the name: the insert uses `ON CONFLICT DO NOTHING`, and a caller whose insert conflicts reads back the winner's row, so both receive the same id rather than one seeing an integrity error.

## MCP is deliberately excluded

`remember` keeps returning its unknown-space error listing the real spaces. A space name arriving there was produced by a model reading a prompt, where a misspelling is likely — and silently creating `wrok` alongside `work` splits a user's memories in a way that is quiet and annoying to undo. An error naming the spaces that exist is the better failure. A test pins this so the two surfaces do not converge by accident.

## Behaviour change worth noting

Two existing tests asserted 404 for ingesting into `no_such_space`. That name contains an underscore, which the space-name rules exclude, so it is now rejected as invalid with 400. The tests assert 400 and are renamed accordingly.

Callers that relied on 404 to detect a missing space will now get a 200 and a created space. Callers sending a name the rules reject get 400 instead of 404.

## Tests

22 tests in `tests/test_ensure_space.py` covering creation, reuse, the concurrent race, every rejection class, and both API surfaces. Verified against the code before this change: ingesting into a new space returned `404 {"detail":"Unknown space: auto-made"}` and created nothing.

300/300 pytest, `ruff check` and `ruff format --check` clean.

### Container verification

Built the image from this branch and ran the full stack, since this changes API behaviour rather than internals:

- all six migrations applied to a fresh volume; both partial-index predicates present and correct
- ingest into a new space returns 200 and the space appears in `GET /api/spaces`
- invalid, reserved, and uppercase names return 400 with a specific message, and create nothing
- file upload into a new space auto-creates it; a repeated passage inside one document is stored twice rather than collapsed
- re-ingesting an unchanged file by path creates 0 additional chunks
- search retrieves from the auto-created space
- MCP `remember` into an unknown space stores nothing and creates nothing
- five concurrent `ensure_space` calls yield one space and one id
- no errors in the application log; auto-creation is logged with the request id

Inspired by @gatesl's work in #52, implemented fresh against the current code.
