### PR TITLE
feat: move a memory between spaces

### DIFF
--- a/src/memory_vault/api/routers/chunks.py
+++ b/src/memory_vault/api/routers/chunks.py
@@ -8,8 +8,15 @@ from datetime import UTC, datetime
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 
 from memory_vault.api.deps import require_token
-from memory_vault.api.schemas import ChunkList, ChunkSummary, ForgetResponse
+from memory_vault.api.schemas import (
+    ChunkList,
+    ChunkMoveRequest,
+    ChunkMoveResponse,
+    ChunkSummary,
+    ForgetResponse,
+)
 from memory_vault.models.db import execute_query, fetch_all, fetch_one
+from memory_vault.services.spaces import ChunkNotFound, SpaceNotFound, move_chunk
 
 router = APIRouter(prefix="/api", tags=["chunks"], dependencies=[Depends(require_token)])
 
@@ -145,3 +152,26 @@ async def forget_chunk(chunk_id: str) -> ForgetResponse:
         chunk_id=chunk_id,
         message=f'Memory forgotten: "{preview}"',
     )
+
+
+@router.post("/chunks/{chunk_id}/move", response_model=ChunkMoveResponse)
+async def move_chunk_endpoint(chunk_id: str, req: ChunkMoveRequest) -> ChunkMoveResponse:
+    """Move a chunk into another existing space.
+
+    The content and embedding are untouched; the chunk's knowledge-graph
+    entries are rebuilt in the target space so the graph and search agree
+    about where the memory lives.
+    """
+    try:
+        result = await move_chunk(chunk_id, req.target_space)
+    except ChunkNotFound as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+    except SpaceNotFound as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+
+    message = (
+        f"Memory moved from '{result['from_space']}' to '{result['to_space']}'."
+        if result["moved"]
+        else f"Memory is already in '{result['to_space']}'."
+    )
+    return ChunkMoveResponse(success=True, message=message, **result)

--- a/src/memory_vault/api/schemas.py
+++ b/src/memory_vault/api/schemas.py
@@ -86,6 +86,25 @@ class ForgetResponse(BaseModel):
     message: str
 
 
+class ChunkMoveRequest(BaseModel):
+    target_space: str = Field(
+        ...,
+        min_length=1,
+        max_length=64,
+        examples=["archive"],
+        description="Name of an existing space to move the memory into.",
+    )
+
+
+class ChunkMoveResponse(BaseModel):
+    success: bool
+    chunk_id: str
+    from_space: str
+    to_space: str
+    moved: bool
+    message: str
+
+
 # ---------------------------------------------------------------------------
 # Spaces
 # ---------------------------------------------------------------------------

--- a/src/memory_vault/mcp/server.py
+++ b/src/memory_vault/mcp/server.py
@@ -54,6 +54,11 @@ from memory_vault.services.search import (  # noqa: E402
     parse_since,
     resolve_space_names,
 )
+from memory_vault.services.spaces import (  # noqa: E402
+    ChunkNotFound,
+    SpaceNotFound,
+    move_chunk,
+)
 
 logging.basicConfig(
     level=logging.INFO,
@@ -481,6 +486,60 @@ async def forget(chunk_id: str) -> str:
     except Exception as e:
         logger.exception("forget failed")
         return _dumps({"success": False, "error": str(e)})
+
+
+@mcp.tool()
+async def move_memory(chunk_id: str, target_space: str) -> str:
+    """
+    Move a stored memory into a different space.
+
+    The memory keeps its content and embedding; only the space it belongs to
+    changes. Its knowledge-graph entries are rebuilt in the target space so
+    the graph and search agree about where it lives.
+
+    The target space must already exist — use the dashboard or the API to
+    create one first.
+
+    Args:
+        chunk_id: The UUID of the chunk to move.
+        target_space: Name of the space to move it into.
+    """
+    if not await _ensure_db():
+        return _dumps({"success": False, "error": "Database offline"})
+
+    try:
+        result = await move_chunk(chunk_id, target_space)
+    except ChunkNotFound:
+        return _dumps({"success": False, "error": f"Chunk {chunk_id} not found."})
+    except SpaceNotFound:
+        available = await fetch_all("SELECT name FROM memory_spaces ORDER BY name")
+        names = [r["name"] for r in available]
+        return _dumps(
+            {
+                "success": False,
+                "error": f"Unknown space '{target_space}'. Available: {names}",
+            }
+        )
+    except Exception as e:
+        logger.exception("move_memory failed")
+        return _dumps({"success": False, "error": str(e)})
+
+    if not result["moved"]:
+        return _dumps(
+            {
+                "success": True,
+                **result,
+                "message": f"Memory is already in '{target_space}'.",
+            }
+        )
+
+    return _dumps(
+        {
+            "success": True,
+            **result,
+            "message": f"Memory moved from '{result['from_space']}' to '{target_space}'.",
+        }
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/src/memory_vault/services/spaces.py
+++ b/src/memory_vault/services/spaces.py
@@ -8,8 +8,9 @@ from __future__ import annotations
 
 import logging
 import re
+from typing import Any
 
-from memory_vault.models.db import execute_returning, fetch_one
+from memory_vault.models.db import execute_returning, fetch_one, get_pool
 
 logger = logging.getLogger(__name__)
 
@@ -87,6 +88,76 @@ async def get_space_id(name: str) -> int | None:
     """Return the id of an existing space, or None."""
     row = await fetch_one("SELECT id FROM memory_spaces WHERE name = %s", (name,))
     return int(row["id"]) if row else None
+
+
+class ChunkNotFound(LookupError):
+    """No chunk with the given id."""
+
+
+class SpaceNotFound(LookupError):
+    """No space with the given name."""
+
+
+async def move_chunk(chunk_id: str, target_space: str) -> dict[str, Any]:
+    """Move a chunk into `target_space`, keeping its graph entries consistent.
+
+    The target space must already exist: moving is a curation step on stored
+    memories, not a way to bring a space into being, and a typo here should
+    fail rather than scatter memories into a new near-identical space.
+
+    The chunk's embedding is unchanged — only its space changes, so the text
+    is never re-embedded. Its extracted entities are another matter. Entities
+    are per-space, while mentions hang off the chunk, so a chunk that moves
+    without them leaves its entities behind in the space it came from and the
+    graph disagrees with search about where the memory lives. The mentions and
+    relationships are therefore dropped and extraction is re-run against the
+    target space. Entities left with no live mentions fall out of the graph
+    views on their own.
+    """
+    from memory_vault.services.ingestion import _run_extraction
+
+    chunk = await fetch_one(
+        """SELECT c.id, c.content, c.space_id, ms.name AS space_name
+           FROM chunks c JOIN memory_spaces ms ON ms.id = c.space_id
+           WHERE c.id = %s""",
+        (chunk_id,),
+    )
+    if chunk is None:
+        raise ChunkNotFound(f"Chunk not found: {chunk_id}")
+
+    target_id = await get_space_id(target_space)
+    if target_id is None:
+        raise SpaceNotFound(f"Unknown space: {target_space}")
+
+    source_space = str(chunk["space_name"])
+    if int(chunk["space_id"]) == target_id:
+        return {
+            "chunk_id": str(chunk["id"]),
+            "from_space": source_space,
+            "to_space": target_space,
+            "moved": False,
+        }
+
+    pool = await get_pool()
+    async with pool.connection() as conn:
+        async with conn.transaction():
+            await conn.execute(
+                "UPDATE chunks SET space_id = %s, updated_at = now() WHERE id = %s",
+                (target_id, chunk_id),
+            )
+            await conn.execute("DELETE FROM entity_mentions WHERE chunk_id = %s", (chunk_id,))
+            await conn.execute("DELETE FROM relationships WHERE chunk_id = %s", (chunk_id,))
+
+    # Outside the transaction: extraction is best-effort and must not undo a
+    # move that has already succeeded.
+    await _run_extraction(str(chunk["id"]), str(chunk["content"]), target_id)
+
+    return {
+        "chunk_id": str(chunk["id"]),
+        "from_space": source_space,
+        "to_space": target_space,
+        "moved": True,
+    }
 
 
 async def ensure_space(name: str) -> int:

--- a/tests/test_move_memory.py
+++ b/tests/test_move_memory.py
@@ -1,0 +1,206 @@
+"""Moving a memory between spaces keeps search and the graph in agreement."""
+
+import json
+
+import pytest
+import pytest_asyncio
+
+from memory_vault.mcp import server as mcp_server
+from memory_vault.models.db import execute_query, fetch_all, fetch_one
+from memory_vault.services import spaces
+from memory_vault.services.ingestion import ingest_text
+
+pytestmark = pytest.mark.asyncio
+
+SRC = "move-src"
+DST = "move-dst"
+_SPACE_NAMES = (SRC, DST)
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _spaces():
+    async def remove() -> None:
+        await execute_query(
+            """DELETE FROM chunks WHERE space_id IN (
+                   SELECT id FROM memory_spaces WHERE name = ANY(%s))""",
+            (list(_SPACE_NAMES),),
+            commit=True,
+        )
+        await execute_query(
+            """DELETE FROM entities WHERE space_id IN (
+                   SELECT id FROM memory_spaces WHERE name = ANY(%s))""",
+            (list(_SPACE_NAMES),),
+            commit=True,
+        )
+        await execute_query(
+            "DELETE FROM memory_spaces WHERE name = ANY(%s)",
+            (list(_SPACE_NAMES),),
+            commit=True,
+        )
+
+    await remove()
+    await spaces.ensure_space(SRC)
+    await spaces.ensure_space(DST)
+    yield
+    await remove()
+
+
+async def _space_of(chunk_id: str) -> str:
+    row = await fetch_one(
+        """SELECT ms.name FROM chunks c JOIN memory_spaces ms ON ms.id = c.space_id
+           WHERE c.id = %s""",
+        (chunk_id,),
+    )
+    return row["name"]
+
+
+async def _entity_spaces(chunk_id: str) -> set[str]:
+    rows = await fetch_all(
+        """SELECT DISTINCT ms.name FROM entities e
+           JOIN memory_spaces ms ON ms.id = e.space_id
+           JOIN entity_mentions em ON em.entity_id = e.id
+           WHERE em.chunk_id = %s""",
+        (chunk_id,),
+    )
+    return {r["name"] for r in rows}
+
+
+async def test_move_changes_the_chunks_space():
+    chunk_id = await ingest_text("a memory that will be moved", space=SRC)
+    assert await _space_of(chunk_id) == SRC
+
+    result = await spaces.move_chunk(chunk_id, DST)
+
+    assert result["moved"] is True
+    assert result["from_space"] == SRC
+    assert result["to_space"] == DST
+    assert await _space_of(chunk_id) == DST
+
+
+async def test_move_does_not_reembed_the_content():
+    """The embedding is untouched — only the space changes."""
+    chunk_id = await ingest_text("vectors should survive the move", space=SRC)
+    before = await fetch_one("SELECT embedding FROM chunks WHERE id = %s", (chunk_id,))
+
+    await spaces.move_chunk(chunk_id, DST)
+
+    after = await fetch_one("SELECT embedding FROM chunks WHERE id = %s", (chunk_id,))
+    assert str(before["embedding"]) == str(after["embedding"])
+
+
+async def test_move_rebuilds_the_graph_in_the_target_space():
+    """Entities follow the memory instead of staying behind.
+
+    Entities are per-space while mentions hang off the chunk, so moving the
+    chunk alone leaves its entities in the space it came from — the graph then
+    disagrees with search about where the memory lives.
+    """
+    chunk_id = await ingest_text("Mihai works with Postgres in Cluj", space=SRC)
+    assert await _entity_spaces(chunk_id) == {SRC}, "no entities extracted to begin with"
+
+    await spaces.move_chunk(chunk_id, DST)
+
+    assert await _entity_spaces(chunk_id) == {DST}
+
+
+async def test_moving_into_the_same_space_is_a_no_op():
+    chunk_id = await ingest_text("staying put", space=SRC)
+
+    result = await spaces.move_chunk(chunk_id, SRC)
+
+    assert result["moved"] is False
+    assert await _space_of(chunk_id) == SRC
+
+
+async def test_move_rejects_an_unknown_chunk():
+    with pytest.raises(spaces.ChunkNotFound):
+        await spaces.move_chunk("00000000-0000-0000-0000-000000000000", DST)
+
+
+async def test_move_rejects_an_unknown_target_space():
+    """The target must exist — moving never creates a space."""
+    chunk_id = await ingest_text("should not move", space=SRC)
+
+    with pytest.raises(spaces.SpaceNotFound):
+        await spaces.move_chunk(chunk_id, "no-such-target")
+
+    assert await _space_of(chunk_id) == SRC
+    row = await fetch_one("SELECT 1 FROM memory_spaces WHERE name = %s", ("no-such-target",))
+    assert row is None, "a failed move created the target space"
+
+
+class TestMoveOverRest:
+    async def test_move_endpoint_moves_the_chunk(self, client, auth_headers):
+        chunk_id = await ingest_text("moved over http", space=SRC)
+
+        resp = await client.post(
+            f"/api/chunks/{chunk_id}/move",
+            headers=auth_headers,
+            json={"target_space": DST},
+        )
+
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["success"] is True
+        assert body["moved"] is True
+        assert body["from_space"] == SRC
+        assert body["to_space"] == DST
+        assert await _space_of(chunk_id) == DST
+
+    async def test_move_endpoint_404s_for_an_unknown_chunk(self, client, auth_headers):
+        resp = await client.post(
+            "/api/chunks/00000000-0000-0000-0000-000000000000/move",
+            headers=auth_headers,
+            json={"target_space": DST},
+        )
+        assert resp.status_code == 404
+
+    async def test_move_endpoint_404s_for_an_unknown_space(self, client, auth_headers):
+        chunk_id = await ingest_text("stays here", space=SRC)
+
+        resp = await client.post(
+            f"/api/chunks/{chunk_id}/move",
+            headers=auth_headers,
+            json={"target_space": "no-such-target"},
+        )
+
+        assert resp.status_code == 404
+        assert await _space_of(chunk_id) == SRC
+
+
+class TestMoveOverMcp:
+    async def test_move_memory_tool_moves_the_chunk(self):
+        chunk_id = await ingest_text("moved over mcp", space=SRC)
+
+        result = json.loads(await mcp_server.move_memory(chunk_id, DST))
+
+        assert result["success"] is True
+        assert result["moved"] is True
+        assert await _space_of(chunk_id) == DST
+
+    async def test_move_memory_tool_reports_an_unknown_chunk(self):
+        result = json.loads(
+            await mcp_server.move_memory("00000000-0000-0000-0000-000000000000", DST)
+        )
+        assert result["success"] is False
+        assert "not found" in result["error"].lower()
+
+    async def test_move_memory_tool_lists_spaces_for_an_unknown_target(self):
+        """The unknown-space error names the real spaces, as `remember` does."""
+        chunk_id = await ingest_text("stays put", space=SRC)
+
+        result = json.loads(await mcp_server.move_memory(chunk_id, "no-such-target"))
+
+        assert result["success"] is False
+        assert "Unknown space" in result["error"]
+        assert SRC in result["error"]
+        assert await _space_of(chunk_id) == SRC
+
+    async def test_move_memory_tool_does_not_create_the_target_space(self):
+        """Moving never creates a space, matching `remember`'s refusal."""
+        chunk_id = await ingest_text("no space creation", space=SRC)
+
+        json.loads(await mcp_server.move_memory(chunk_id, "conjured-by-move"))
+
+        row = await fetch_one("SELECT 1 FROM memory_spaces WHERE name = %s", ("conjured-by-move",))
+        assert row is None


### PR DESCRIPTION
## Change

A memory can now be moved between spaces:

- `move_memory(chunk_id, target_space)` on the MCP surface
- `POST /api/chunks/{chunk_id}/move` with `{"target_space": "archive"}`

The content and embedding are untouched, so nothing is re-embedded and the original timestamp survives. Previously the only way to change a chunk's space was to delete it and ingest the same text again.

## The graph has to move with it

Entities are per-space (`entities.space_id`, unique on name+type+space), while `entity_mentions` and `relationships` hang off `chunk_id`. So updating the chunk's `space_id` alone strands its entities in the space it came from — search reports the memory in the new space while the graph still shows it under the old one. Confirmed against a real database before choosing the fix:

```
chunk moved to red-dst; its entities live in: {'red-src'}
```

The move now deletes the chunk's mentions and relationships and re-runs extraction against the target space. Entities left with no live mentions drop out of the graph views on their own.

The `UPDATE` and the mention deletion share one transaction. Re-extraction runs *after* it, deliberately: extraction is best-effort and swallows its own errors, so running it inside would let a graph failure roll back a move that already succeeded.

## The target space must exist

Moving is curation of stored memories, not a way to bring a space into being. A mistyped target fails with the list of real spaces rather than scattering memories into a new near-identical space — the same reasoning that keeps `remember` from creating spaces. Moving a chunk into the space it is already in is a no-op that reports `moved: false` rather than an error.

## Tests

13 tests in `tests/test_move_memory.py`: the move itself, embedding preserved, graph rebuilt in the target, same-space no-op, unknown chunk, unknown target, and both surfaces including that a failed move creates nothing.

314/314 pytest, `ruff check` and `ruff format --check` clean.

Inspired by @gatesl's work in #52, implemented fresh against the current code.

