### PR TITLE
refactor: read the knowledge graph through live views

### DIFF
--- a/src/memory_vault/api/routers/graph.py
+++ b/src/memory_vault/api/routers/graph.py
@@ -53,19 +53,17 @@ async def list_entities(
     # templates ("ms.name = %s", "e.type = %s"). User values go through %s
     # parameters in `params`. No user-controlled SQL fragments.
     # Subquery builds entity + mention_count, then filters by min_mentions.
-    # Mentions on forgotten chunks are excluded so mention_count reflects only
-    # live mentions and entities with zero live mentions drop out via HAVING.
+    # Reading mentions through live_entity_mentions keeps forgotten chunks out
+    # of the count, so entities with zero live mentions drop out via HAVING.
     base_sql = f"""
         SELECT e.id, e.name, e.type, ms.name AS space_name, e.created_at,
-               COUNT(c.id) AS mention_count
+               COUNT(em.id) AS mention_count
         FROM entities e
         JOIN memory_spaces ms ON ms.id = e.space_id
-        LEFT JOIN entity_mentions em ON em.entity_id = e.id
-        LEFT JOIN chunks c ON c.id = em.chunk_id
-            AND (c.metadata->>'forgotten')::boolean IS NOT TRUE
+        LEFT JOIN live_entity_mentions em ON em.entity_id = e.id
         WHERE {where_sql}
         GROUP BY e.id, ms.name
-        HAVING COUNT(c.id) >= %s
+        HAVING COUNT(em.id) >= %s
     """  # nosec B608
 
     count_sql = f"SELECT COUNT(*) AS total FROM ({base_sql}) sub"  # nosec B608
@@ -102,11 +100,8 @@ async def get_entity(entity_id: str) -> EntityDetail:
     entity = await fetch_one(
         """SELECT e.id, e.name, e.type, ms.name AS space_name, e.created_at,
                   (SELECT COUNT(*)
-                     FROM entity_mentions em
-                     JOIN chunks c ON c.id = em.chunk_id
-                    WHERE em.entity_id = e.id
-                      AND (c.metadata->>'forgotten')::boolean IS NOT TRUE)
-                      AS mention_count
+                     FROM live_entity_mentions em
+                    WHERE em.entity_id = e.id) AS mention_count
            FROM entities e
            JOIN memory_spaces ms ON ms.id = e.space_id
            WHERE e.id = %s""",
@@ -118,35 +113,29 @@ async def get_entity(entity_id: str) -> EntityDetail:
             detail=f"Entity not found: {entity_id}",
         )
 
-    # All live mentions with a short chunk preview, newest first. Forgotten
-    # chunks are excluded so their preview text never surfaces here.
+    # All live mentions with a short chunk preview, newest first. The view
+    # keeps forgotten chunks out, so their preview text never surfaces here.
     mention_rows = await fetch_all(
         """SELECT em.chunk_id, em.start_offset, em.end_offset,
                   LEFT(c.content, %s) AS chunk_preview
-           FROM entity_mentions em
+           FROM live_entity_mentions em
            JOIN chunks c ON c.id = em.chunk_id
            WHERE em.entity_id = %s
-             AND (c.metadata->>'forgotten')::boolean IS NOT TRUE
            ORDER BY em.created_at DESC""",
         (CHUNK_PREVIEW_LEN, entity_id),
     )
 
-    # Related entities via relationships (both directions), aggregated. A
-    # relationship backed by a forgotten chunk drops out; a relationship with
-    # no backing chunk (chunk_id IS NULL, from future manual/LLM tagging) stays.
+    # Related entities via relationships (both directions), aggregated. The
+    # view drops relationships backed by a forgotten chunk while keeping those
+    # with no backing chunk at all.
     related_rows = await fetch_all(
         """SELECT other.id, other.name, other.type, COUNT(*) AS co_mention_count
-           FROM relationships r
+           FROM live_relationships r
            JOIN entities other ON other.id = CASE
                WHEN r.source_entity_id = %s THEN r.target_entity_id
                ELSE r.source_entity_id
            END
            WHERE (r.source_entity_id = %s OR r.target_entity_id = %s)
-             AND NOT EXISTS (
-                 SELECT 1 FROM chunks c
-                 WHERE c.id = r.chunk_id
-                   AND (c.metadata->>'forgotten')::boolean IS TRUE
-             )
            GROUP BY other.id, other.name, other.type
            ORDER BY co_mention_count DESC, other.name ASC""",
         (entity_id, entity_id, entity_id),
@@ -193,16 +182,10 @@ async def list_relationships(
     limit: int = Query(default=50, ge=1, le=500),
     offset: int = Query(default=0, ge=0),
 ) -> RelationshipList:
-    # Always exclude relationships backed by forgotten chunks; relationships
-    # with chunk_id IS NULL (future manual/LLM-tagged) have no backing chunk
-    # and stay visible.
-    where: list[str] = [
-        "NOT EXISTS ("
-        "SELECT 1 FROM chunks c "
-        "WHERE c.id = r.chunk_id "
-        "AND (c.metadata->>'forgotten')::boolean IS TRUE"
-        ")"
-    ]
+    # Reading from live_relationships excludes rows backed by a forgotten
+    # chunk, while keeping those with chunk_id IS NULL (future manual or
+    # LLM-tagged links, which have no backing chunk to forget).
+    where: list[str] = []
     params: list = []
 
     if entity_id is not None:
@@ -218,12 +201,12 @@ async def list_relationships(
         )
         params.append(space)
 
-    where_sql = " AND ".join(where)
+    where_sql = " AND ".join(where) if where else "TRUE"
 
     # nosec B608 — `where_sql` is composed from a closed set of literal
     # templates; user values are bound via %s parameters.
     count_row = await fetch_one(
-        f"SELECT COUNT(*) AS total FROM relationships r WHERE {where_sql}",  # nosec B608
+        f"SELECT COUNT(*) AS total FROM live_relationships r WHERE {where_sql}",  # nosec B608
         tuple(params),
     )
     total = int(count_row["total"]) if count_row else 0
@@ -232,7 +215,7 @@ async def list_relationships(
         f"""SELECT r.id, r.source_entity_id, r.target_entity_id, r.type,
                    r.chunk_id, r.created_at,
                    s.name AS source_name, t.name AS target_name
-            FROM relationships r
+            FROM live_relationships r
             JOIN entities s ON s.id = r.source_entity_id
             JOIN entities t ON t.id = r.target_entity_id
             WHERE {where_sql}
@@ -285,19 +268,16 @@ async def visualize(
     # nosec B608 — `where_sql` composed from closed-set literal templates;
     # user values bound via %s parameters.
     # Nodes: pick top `max_nodes` by mention_count, filtered by min_mentions.
-    # Mentions on forgotten chunks are excluded via the LEFT JOIN predicate,
-    # so mention_count reflects only live mentions and nodes with zero live
-    # mentions drop out via HAVING.
+    # Reading mentions through the view keeps forgotten chunks out of the
+    # count, so nodes with zero live mentions drop out via HAVING.
     node_rows = await fetch_all(
-        f"""SELECT e.id, e.name, e.type, COUNT(c.id) AS mention_count
+        f"""SELECT e.id, e.name, e.type, COUNT(em.id) AS mention_count
             FROM entities e
             JOIN memory_spaces ms ON ms.id = e.space_id
-            LEFT JOIN entity_mentions em ON em.entity_id = e.id
-            LEFT JOIN chunks c ON c.id = em.chunk_id
-                AND (c.metadata->>'forgotten')::boolean IS NOT TRUE
+            LEFT JOIN live_entity_mentions em ON em.entity_id = e.id
             WHERE {where_sql}
             GROUP BY e.id
-            HAVING COUNT(c.id) >= %s
+            HAVING COUNT(em.id) >= %s
             ORDER BY mention_count DESC, e.name ASC
             LIMIT %s""",  # nosec B608
         tuple(params + [min_mentions, max_nodes]),
@@ -310,12 +290,10 @@ async def visualize(
                 SELECT e.id
                 FROM entities e
                 JOIN memory_spaces ms ON ms.id = e.space_id
-                LEFT JOIN entity_mentions em ON em.entity_id = e.id
-                LEFT JOIN chunks c ON c.id = em.chunk_id
-                    AND (c.metadata->>'forgotten')::boolean IS NOT TRUE
+                LEFT JOIN live_entity_mentions em ON em.entity_id = e.id
                 WHERE {where_sql}
                 GROUP BY e.id
-                HAVING COUNT(c.id) >= %s
+                HAVING COUNT(em.id) >= %s
             ) sub""",  # nosec B608
         tuple(params + [min_mentions]),
     )
@@ -332,21 +310,17 @@ async def visualize(
         for r in node_rows
     ]
 
-    # Edges: only those connecting two surviving nodes AND backed by a live
-    # chunk (or unbacked — chunk_id IS NULL stays for future manual/LLM tags).
+    # Edges: only those connecting two surviving nodes. The view drops edges
+    # backed by a forgotten chunk and keeps unbacked ones (chunk_id IS NULL,
+    # for future manual or LLM-tagged links).
     edges: list[GraphEdge] = []
     if node_ids:
         edge_rows = await fetch_all(
             """SELECT source_entity_id, target_entity_id, type,
                       COUNT(*) AS weight
-               FROM relationships r
+               FROM live_relationships r
                WHERE source_entity_id = ANY(%s::uuid[])
                  AND target_entity_id = ANY(%s::uuid[])
-                 AND NOT EXISTS (
-                     SELECT 1 FROM chunks c
-                     WHERE c.id = r.chunk_id
-                       AND (c.metadata->>'forgotten')::boolean IS TRUE
-                 )
                GROUP BY source_entity_id, target_entity_id, type
                ORDER BY weight DESC""",
             (node_ids, node_ids),

--- a/src/memory_vault/migrations/007_live_graph_views.sql
+++ b/src/memory_vault/migrations/007_live_graph_views.sql
@@ -1,0 +1,40 @@
+-- Memory Vault — views for the live (non-forgotten) knowledge graph
+--
+-- Forgetting a memory is a soft delete: the chunk stays in the table with
+-- `forgotten` set in its metadata. Every graph query therefore has to exclude
+-- rows backed by a forgotten chunk, and until now each one restated that
+-- predicate itself -- nine times across the graph endpoints, in two different
+-- shapes. A query that forgot it leaked forgotten memories through the graph,
+-- which is what #109 reported.
+--
+-- These views state the rule once. Queries that read from them cannot forget
+-- it, and a new graph surface gets the filter by default rather than by the
+-- author remembering to add it.
+--
+-- The two views are not symmetrical, and the difference is deliberate:
+--
+--   entity_mentions.chunk_id is NOT NULL, so a mention always has a backing
+--   chunk and a plain join expresses "the chunk is not forgotten".
+--
+--   relationships.chunk_id is nullable. A relationship with no backing chunk
+--   is not extracted from a memory -- it is the shape future manual or
+--   LLM-assigned links take -- so it has no chunk that could be forgotten and
+--   must stay visible. An inner join here would silently delete that whole
+--   category from the graph, so the rule is written as "no forgotten chunk
+--   backs this row" rather than "a live chunk backs this row".
+
+CREATE VIEW live_entity_mentions AS
+    SELECT em.*
+    FROM entity_mentions em
+    JOIN chunks c ON c.id = em.chunk_id
+    WHERE (c.metadata->>'forgotten')::boolean IS NOT TRUE;
+
+CREATE VIEW live_relationships AS
+    SELECT r.*
+    FROM relationships r
+    WHERE NOT EXISTS (
+        SELECT 1
+        FROM chunks c
+        WHERE c.id = r.chunk_id
+          AND (c.metadata->>'forgotten')::boolean IS TRUE
+    );

--- a/tests/test_live_graph_views.py
+++ b/tests/test_live_graph_views.py
@@ -1,0 +1,182 @@
+"""The live-graph views hide forgotten memories without hiding anything else."""
+
+import uuid
+
+import pytest
+import pytest_asyncio
+
+from memory_vault.models.db import execute_query, fetch_all, fetch_one
+from memory_vault.services import spaces
+from memory_vault.services.ingestion import ingest_text
+
+pytestmark = pytest.mark.asyncio
+
+SPACE = "views-space"
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _space():
+    async def remove() -> None:
+        await execute_query(
+            """DELETE FROM chunks WHERE space_id IN (
+                   SELECT id FROM memory_spaces WHERE name = %s)""",
+            (SPACE,),
+            commit=True,
+        )
+        await execute_query(
+            """DELETE FROM entities WHERE space_id IN (
+                   SELECT id FROM memory_spaces WHERE name = %s)""",
+            (SPACE,),
+            commit=True,
+        )
+        await execute_query("DELETE FROM memory_spaces WHERE name = %s", (SPACE,), commit=True)
+
+    await remove()
+    space_id = await spaces.ensure_space(SPACE)
+    yield space_id
+    await remove()
+
+
+async def _forget(chunk_id: str) -> None:
+    await execute_query(
+        """UPDATE chunks
+           SET importance = 0,
+               metadata = COALESCE(metadata, '{}'::jsonb) || '{"forgotten": true}'::jsonb
+           WHERE id = %s""",
+        (chunk_id,),
+        commit=True,
+    )
+
+
+async def _mention_rows(chunk_id: str) -> int:
+    row = await fetch_one(
+        "SELECT COUNT(*) AS n FROM live_entity_mentions WHERE chunk_id = %s", (chunk_id,)
+    )
+    return int(row["n"])
+
+
+async def test_forgetting_a_chunk_hides_its_mentions_from_the_view():
+    chunk_id = await ingest_text("Mihai works with Postgres in Cluj", space=SPACE)
+    assert await _mention_rows(chunk_id) > 0, "no mentions extracted to begin with"
+
+    await _forget(chunk_id)
+
+    assert await _mention_rows(chunk_id) == 0
+
+
+async def test_the_view_still_exposes_mentions_on_live_chunks():
+    chunk_id = await ingest_text("Postgres powers the vault", space=SPACE)
+    base = await fetch_all("SELECT id FROM entity_mentions WHERE chunk_id = %s", (chunk_id,))
+
+    live = await fetch_all("SELECT id FROM live_entity_mentions WHERE chunk_id = %s", (chunk_id,))
+
+    assert {r["id"] for r in live} == {r["id"] for r in base}
+
+
+async def test_relationships_without_a_backing_chunk_stay_visible(_space):
+    """A relationship with chunk_id IS NULL has no chunk that could be forgotten.
+
+    These are the shape future manual or LLM-assigned links take. A view built
+    on an inner join would drop the whole category, so the rule is written as
+    "no forgotten chunk backs this row" rather than "a live chunk backs it".
+    """
+    space_id = _space
+    src = str(uuid.uuid4())
+    dst = str(uuid.uuid4())
+    for eid, name in ((src, "alpha-entity"), (dst, "beta-entity")):
+        await execute_query(
+            """INSERT INTO entities (id, name, type, space_id)
+               VALUES (%s, %s, 'concept', %s)""",
+            (eid, name, space_id),
+            commit=True,
+        )
+    rel_id = str(uuid.uuid4())
+    await execute_query(
+        """INSERT INTO relationships (id, source_entity_id, target_entity_id, type, chunk_id)
+           VALUES (%s, %s, %s, 'relates_to', NULL)""",
+        (rel_id, src, dst),
+        commit=True,
+    )
+
+    row = await fetch_one("SELECT id FROM live_relationships WHERE id = %s", (rel_id,))
+
+    assert row is not None, "an unbacked relationship was hidden by the view"
+
+
+async def test_forgetting_a_chunk_hides_its_relationships():
+    # Text chosen because extraction reliably produces relationships from it —
+    # a shorter phrase yields entities but no links, which would leave this
+    # test asserting nothing.
+    chunk_id = await ingest_text("Sarah works on Postgres and uses Docker", space=SPACE)
+    before = await fetch_all("SELECT id FROM live_relationships WHERE chunk_id = %s", (chunk_id,))
+    assert before, "no relationships extracted to begin with"
+
+    await _forget(chunk_id)
+
+    after = await fetch_all("SELECT id FROM live_relationships WHERE chunk_id = %s", (chunk_id,))
+    assert after == []
+
+    # The rows are hidden, not deleted — forgetting is a soft delete.
+    raw = await fetch_all("SELECT id FROM relationships WHERE chunk_id = %s", (chunk_id,))
+    assert len(raw) == len(before)
+
+
+class TestGraphEndpointsHideForgottenMemories:
+    """The endpoints read through the views, so forgetting is reflected there."""
+
+    async def test_entity_list_drops_entities_whose_only_chunk_is_forgotten(
+        self, client, auth_headers
+    ):
+        chunk_id = await ingest_text("Docker runs on Linux at Google", space=SPACE)
+
+        resp = await client.get(f"/api/graph/entities?space={SPACE}", headers=auth_headers)
+        assert resp.status_code == 200
+        before = {e["name"] for e in resp.json()["entities"]}
+        assert before, "no entities extracted to begin with"
+
+        await _forget(chunk_id)
+
+        resp = await client.get(f"/api/graph/entities?space={SPACE}", headers=auth_headers)
+        after = {e["name"] for e in resp.json()["entities"]}
+        assert after == set(), f"forgotten memory still visible as entities: {after}"
+
+    async def test_visualize_drops_nodes_for_forgotten_memories(self, client, auth_headers):
+        chunk_id = await ingest_text("Docker runs on Linux at Google", space=SPACE)
+
+        resp = await client.get(f"/api/graph/visualize?space={SPACE}", headers=auth_headers)
+        assert resp.status_code == 200
+        assert resp.json()["nodes"], "no nodes to begin with"
+
+        await _forget(chunk_id)
+
+        resp = await client.get(f"/api/graph/visualize?space={SPACE}", headers=auth_headers)
+        body = resp.json()
+        assert body["nodes"] == []
+        assert body["edges"] == []
+
+    async def test_relationship_list_still_answers(self, client, auth_headers):
+        """The endpoint works with no filters, where the WHERE clause is empty.
+
+        Removing the always-present forgotten predicate left `where` able to be
+        empty, which would produce `WHERE ` and a syntax error if unguarded.
+        """
+        resp = await client.get("/api/graph/relationships", headers=auth_headers)
+        assert resp.status_code == 200, resp.text
+        assert "relationships" in resp.json()
+
+    async def test_entity_detail_hides_mentions_of_forgotten_chunks(self, client, auth_headers):
+        chunk_id = await ingest_text("Redis caches responses", space=SPACE)
+        resp = await client.get(f"/api/graph/entities?space={SPACE}", headers=auth_headers)
+        entities = resp.json()["entities"]
+        assert entities, "no entities extracted to begin with"
+        entity_id = entities[0]["id"]
+
+        detail = await client.get(f"/api/graph/entities/{entity_id}", headers=auth_headers)
+        assert detail.json()["mentions"], "no mentions to begin with"
+
+        await _forget(chunk_id)
+
+        detail = await client.get(f"/api/graph/entities/{entity_id}", headers=auth_headers)
+        body = detail.json()
+        assert body["mentions"] == []
+        assert body["mention_count"] == 0


### PR DESCRIPTION
## Why

Forgetting a memory is a soft delete — the chunk stays in the table with `forgotten` set in its metadata. Every graph query therefore has to exclude rows backed by a forgotten chunk, and each one restated that predicate itself:

```
9 occurrences across the graph endpoints, in two different shapes:
  (c.metadata->>'forgotten')::boolean IS NOT TRUE      -- for mentions
  NOT EXISTS (... AND ... IS TRUE)                     -- for relationships
```

A query that omitted it leaked forgotten memories into the graph, which is what #109 reported. That was fixed by writing the predicate into every query by hand, which works but leaves the next graph surface one forgotten `WHERE` clause away from the same bug.

## Change

Migration 007 adds two views, and the four graph endpoints read from them:

- `live_entity_mentions`
- `live_relationships`

The rule is now stated once. A new graph query gets it by default rather than by the author remembering to add it.

## The two views are deliberately different

This is the part worth reviewing:

```sql
CREATE VIEW live_entity_mentions AS
    SELECT em.* FROM entity_mentions em
    JOIN chunks c ON c.id = em.chunk_id
    WHERE (c.metadata->>'forgotten')::boolean IS NOT TRUE;

CREATE VIEW live_relationships AS
    SELECT r.* FROM relationships r
    WHERE NOT EXISTS (
        SELECT 1 FROM chunks c
        WHERE c.id = r.chunk_id
          AND (c.metadata->>'forgotten')::boolean IS TRUE
    );
```

`entity_mentions.chunk_id` is `NOT NULL`, so a mention always has a backing chunk and a join says exactly what is meant.

`relationships.chunk_id` is nullable. A relationship with no backing chunk is not extracted from a memory — it is the shape future manual or LLM-assigned links take — so it has no chunk that could be forgotten and must stay visible. An inner join there would silently drop that entire category from the graph, so the rule is written as "no forgotten chunk backs this row" instead.

## Behaviour is unchanged

This is a refactor, not a fix. #109 is already closed and the endpoints already filtered correctly. Both implementations were run against identical data — one live memory, one forgotten — and compared: the same entities, relationships, and graph payloads come back from all three endpoints.

## Tests

8 tests in `tests/test_live_graph_views.py`:

- forgetting a chunk hides its mentions and its relationships from the views
- the views still expose everything on live chunks, and the underlying rows are hidden rather than deleted
- a relationship with `chunk_id IS NULL` stays visible — the case an inner join would have broken
- the four endpoints reflect forgetting through the views
- `/api/graph/relationships` still answers with no filters applied, where the `WHERE` clause is now empty

322/322 pytest, and the same 322 in the containerised test run. `ruff check` and `ruff format --check` clean.
