### PR TITLE
deps: migrate the MCP server to the mcp 2.x API

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,11 +16,10 @@ dependencies = [
     "sentence-transformers>=5.7.0,<6",
     "numpy>=2.4.6",
     "python-dotenv>=1.2.2",
-    # Pinned <2.0.0 — mcp 2.0.0 (released 2026-07-28) removed mcp.server.fastmcp
-    # which server.py imports. 1.29.0 is the final maintained 1.x release cut
-    # on the same day for exactly this scenario. Migration to the 2.0.0 API
-    # shape is planned for v1.1.
-    "mcp>=1.28.1,<2.0.0",
+    # 2.x replaced mcp.server.fastmcp with mcp.server.mcpserver, so 1.x and 2.x
+    # cannot both be supported by one import. The floor is 2.0.0 for that
+    # reason rather than a feature need.
+    "mcp>=2.0.0,<3.0.0",
     "fastapi>=0.141.1,<1",
     "uvicorn[standard]>=0.52.2,<1",
     "python-multipart>=0.0.32",

--- a/src/memory_vault/mcp/server.py
+++ b/src/memory_vault/mcp/server.py
@@ -37,7 +37,7 @@ _project_root = str(Path(__file__).parents[2])
 if _project_root not in sys.path:
     sys.path.insert(0, _project_root)
 
-from mcp.server.fastmcp import FastMCP  # noqa: E402
+from mcp.server.mcpserver import MCPServer  # noqa: E402
 
 from memory_vault.models.db import (  # noqa: E402
     execute_query,
@@ -127,7 +127,7 @@ def _budget_results(results: list[dict], max_tokens: int) -> tuple[list[dict], b
 # MCP server instance
 # ---------------------------------------------------------------------------
 
-mcp = FastMCP("memory-vault")
+mcp = MCPServer("memory-vault")
 
 # ---------------------------------------------------------------------------
 # DB lifecycle

--- a/tests/test_mcp_server_import.py
+++ b/tests/test_mcp_server_import.py
@@ -16,22 +16,66 @@ obvious ("MCP server module failed to import") when it triggers.
 
 from __future__ import annotations
 
+import pytest
+
+TOOL_NAMES = ("recall", "remember", "forget", "memory_status", "move_memory")
+
 
 def test_mcp_server_module_imports_cleanly():
     """Import the MCP server module. Any ImportError here blocks the release."""
     import memory_vault.mcp.server as mcp_server
 
-    # Confirm the FastMCP instance was constructed at module load. If mcp.server.fastmcp
-    # is missing (mcp 2.0.0+) the import above already raised — this line is defensive
-    # against a future refactor that turns FastMCP into a lazy factory.
+    # Confirm the server instance was constructed at module load. If the SDK
+    # moved the class again the import above already raised — this line is
+    # defensive against a future refactor that makes it a lazy factory.
     assert mcp_server.mcp is not None
 
 
-def test_mcp_server_tools_are_registered():
-    """The four canonical tools must be present on the server module."""
+def test_mcp_server_tools_are_exported():
+    """The canonical tools must be present on the server module."""
     import memory_vault.mcp.server as mcp_server
 
-    for tool_name in ("recall", "remember", "forget", "memory_status"):
+    for tool_name in TOOL_NAMES:
         assert hasattr(mcp_server, tool_name), (
             f"MCP tool `{tool_name}` is not exported from memory_vault.mcp.server"
         )
+
+
+@pytest.mark.asyncio
+async def test_mcp_tools_are_registered_with_the_server():
+    """The tools are registered on the server, not merely defined in the module.
+
+    Checking module attributes alone would still pass if the decorator stopped
+    registering: the functions would exist and the server would advertise
+    nothing. Asking the server what it exposes is what a client actually sees.
+    """
+    import memory_vault.mcp.server as mcp_server
+
+    tools = await mcp_server.mcp.list_tools()
+    registered = {t.name for t in tools}
+
+    missing = set(TOOL_NAMES) - registered
+    assert not missing, f"tools defined but not registered with the server: {missing}"
+
+
+@pytest.mark.asyncio
+async def test_registered_tools_advertise_their_arguments():
+    """Each tool exposes a schema and a description, so a client can use it.
+
+    A tool that registers with an empty schema imports and lists cleanly while
+    being uncallable from the client side.
+    """
+    import memory_vault.mcp.server as mcp_server
+
+    tools = {t.name: t for t in await mcp_server.mcp.list_tools()}
+
+    assert "text" in tools["remember"].input_schema.get("properties", {})
+    assert "query" in tools["recall"].input_schema.get("properties", {})
+    assert "chunk_id" in tools["forget"].input_schema.get("properties", {})
+    for name in ("chunk_id", "target_space"):
+        assert name in tools["move_memory"].input_schema.get("properties", {})
+
+    # The docstring is what a client shows a user; an empty description means
+    # the tool arrived without its explanation.
+    for name in TOOL_NAMES:
+        assert (tools[name].description or "").strip(), f"{name} has no description"


### PR DESCRIPTION
Supersedes #141, which bumps the pin on its own. The bump alone leaves the server importing a module that 2.x removed, so the code change has to travel with it.

## Change

`mcp` 2.0.0 removed `mcp.server.fastmcp`, which is why the SDK has been pinned below it and the server has been running on the last 1.x release. The class moved and was renamed:

```python
-from mcp.server.fastmcp import FastMCP
-mcp = FastMCP("memory-vault")
+from mcp.server.mcpserver import MCPServer
+mcp = MCPServer("memory-vault")
```

That is the whole migration. The constructor still takes the server name positionally, `@mcp.tool()` still derives the schema from the signature and the description from the docstring, and `run()` still defaults to stdio — checked against the 2.0.0 API before changing anything.

The pin becomes `>=2.0.0,<3.0.0`. One import cannot satisfy both majors, so the floor exists for that reason rather than a feature need.

## The smoke test was weaker than it looked

It asserted the tool functions exist as module attributes. That passes even if the decorator stops registering them — the functions would still be defined and the server would advertise nothing, which is close to the failure that shipped as v1.0.9.

It now asks the server what it actually exposes:

- every tool appears in `list_tools()`, not just in the module namespace
- each one arrives with the arguments a client needs (`remember.text`, `recall.query`, `forget.chunk_id`, `move_memory.chunk_id`/`target_space`)
- each one has a non-empty description, since that is what a client shows a user

## Verified beyond the suite

A green suite is not sufficient here — the v1.0.9 breakage was an image that imported fine under test. So the server was driven over stdio through a real client exchange:

```
initialize   -> serverInfo.name = "memory-vault"
tools/list   -> forget, memory_status, move_memory, recall, remember
tools/call   -> memory_status returned {"status": "online", "database": "connected", ...}
```

The same exchange was then run against a freshly built MCP-only image, since that image is the artifact that broke last time and nothing in the suite builds it. Identical result.

324/324 pytest, and the same 324 in the containerised run. `ruff check` and `ruff format --check` clean.

Closes #141
