### PR TITLE
fix(mcp): recall writes query_log so queries_24h reports real usage

### DIFF
--- a/src/memory_vault/mcp/server.py
+++ b/src/memory_vault/mcp/server.py
@@ -51,6 +51,7 @@ from memory_vault.services.embedding import MODEL_NAME, embed  # noqa: E402
 from memory_vault.services.ingestion import _run_extraction  # noqa: E402
 from memory_vault.services.search import (  # noqa: E402
     hybrid_search,
+    log_query,
     parse_since,
     resolve_space_names,
 )
@@ -207,6 +208,10 @@ async def recall(
             since=since_dt,
             limit=limit,
         )
+
+        # Observability: memory_status reads queries_24h from query_log,
+        # which nothing on the MCP path fed until now.
+        await log_query(query, space_ids or None, results, elapsed_ms)
 
         formatted = []
         for r in results:

--- a/tests/test_query_logging.py
+++ b/tests/test_query_logging.py
@@ -1,0 +1,33 @@
+"""
+Query logging — MCP recall writes to query_log.
+
+memory_status reports queries_24h from query_log; recall must feed it
+(the observability counter previously always read 0 for MCP usage).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from memory_vault.mcp import server as mcp_server
+
+
+@pytest.mark.asyncio
+async def test_recall_writes_query_log():
+    await mcp_server.remember(text="Query logging smoke fact about llamas.")
+
+    res = json.loads(await mcp_server.recall(query="tell me about llamas"))
+    assert res["status"] == "ok"
+
+    from memory_vault.models.db import fetch_one
+
+    row = await fetch_one(
+        "SELECT query_text, result_count, latency_ms FROM query_log "
+        "ORDER BY created_at DESC LIMIT 1"
+    )
+    assert row is not None
+    assert row["query_text"] == "tell me about llamas"
+    assert row["result_count"] >= 1
+    assert row["latency_ms"] is not None


### PR DESCRIPTION
## Summary

`log_query()` exists in `services/search.py` but has no callers on the MCP path. The REST `/api/search` endpoint (`api/routers/search.py:43`) is its only caller, so on an MCP-only deployment `memory_status` and `memory://stats` always report `queries_24h: 0` and `avg_latency_ms: null` however much the vault is used. This wires `recall` to log each query after `hybrid_search`, so the observability surface reflects MCP traffic too.

## Related issue

None — small fix with a regression test.

## Type of change

- [x] Bug fix

## How was this tested?

`tests/test_query_logging.py` — fails before the fix (`query_log` stays empty after a `recall`) and passes after. Full suite + `ruff check .` green locally (py311).
