### PR TITLE
fix(search): importance/recency boosts must not bury retrieval rank

### DIFF
--- a/src/memory_vault/services/search.py
+++ b/src/memory_vault/services/search.py
@@ -435,19 +435,26 @@ async def hybrid_search(
         if info["fts_rank"] is not None:
             rrf += _FTS_WEIGHT / (_RRF_K + info["fts_rank"])
 
+        # Importance and recency modulate the retrieval score rather than
+        # adding to it. Additive boosts (max +0.20) dwarfed the RRF rank
+        # signal (rank 1 contributes ~0.016), so any recent high-importance
+        # chunk outscored an exact match with default importance — burying
+        # rank-1 results beyond the visible window. As multipliers (max
+        # 1.2x) they break ties between similarly-relevant chunks but can
+        # never invert a clear retrieval-rank difference.
         row = info["row"]
-        importance = row.get("importance") or 0.5
-        rrf += _IMPORTANCE_WEIGHT * float(importance)
+        importance = float(row.get("importance") or 0.5)
+        boost = 1.0 + _IMPORTANCE_WEIGHT * importance
 
         created = row.get("created_at")
         if created:
             if created.tzinfo is None:
                 created = created.replace(tzinfo=UTC)
             age_days = max((now_utc - created).days, 0)
-            recency_boost = 1.0 / (1.0 + age_days / _RECENCY_HALF_LIFE_DAYS)
-            rrf += _RECENCY_MAX_BOOST * recency_boost
+            recency_factor = 1.0 / (1.0 + age_days / _RECENCY_HALF_LIFE_DAYS)
+            boost += _RECENCY_MAX_BOOST * recency_factor
 
-        scored.append((rrf, cid, info))
+        scored.append((rrf * boost, cid, info))
 
     scored.sort(key=lambda x: x[0], reverse=True)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,11 @@ os.environ.setdefault("DB_PORT", "5432")
 os.environ["DB_NAME"] = "memory_vault_test"
 os.environ.setdefault("DB_USER", "memory_vault")
 os.environ.setdefault("DB_PASSWORD", "memory_vault")
+# Hermetic model config: tests must not inherit an operator .env that
+# points at a different embedding model/dimension than the migrated
+# test schema (001 creates vector(384)).
+os.environ["EMBEDDING_MODEL"] = "all-MiniLM-L6-v2"
+os.environ["EMBEDDING_DIMENSIONS"] = "384"
 os.environ["API_AUTH_ENABLED"] = "true"
 os.environ["API_RATE_LIMIT_PER_MIN"] = "100000"  # effectively unlimited for tests
 

--- a/tests/test_ranking_dominance.py
+++ b/tests/test_ranking_dominance.py
@@ -1,0 +1,39 @@
+"""
+Ranking: retrieval rank must dominate importance/recency boosts.
+
+The importance (max +0.15) and recency (max +0.05) boosts were additive
+on top of RRF scores whose rank-1 contribution is only ~0.016, so any
+recent high-importance chunk outscored an exact match with default
+importance — burying it beyond the top results. Boosts must scale the
+RRF score, not swamp it: a chunk that is rank 1 in BOTH arms cannot be
+pushed out of the top results by boosts alone.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from memory_vault.mcp import server as mcp_server
+
+
+@pytest.mark.asyncio
+async def test_dual_rank1_match_beats_recent_high_importance_chunks():
+    # A field of fresh, high-importance chunks (classified as decisions),
+    # semantically unrelated to the probe query.
+    for i in range(12):
+        await mcp_server.remember(
+            text=f"We decided to adopt build pipeline number {i} for the web deployment."
+        )
+
+    # The probe: default importance ("fact"), exact match for the query.
+    probe = json.loads(
+        await mcp_server.remember(text="The vault's mascot is a stuffed capybara named Ada.")
+    )
+
+    res = json.loads(await mcp_server.recall(query="vault mascot capybara", limit=3))
+    top_ids = [r["chunk_id"] for r in res["results"]]
+    assert probe["chunk_id"] in top_ids, (
+        "exact match (rank 1 in both arms) must not be buried by importance/recency boosts"
+    )


### PR DESCRIPTION
## Summary

Makes the importance/recency boosts multiplicative instead of additive, so they break ties between similarly-relevant chunks but can never invert a clear retrieval-rank difference. Before this change, a chunk ranked #1 by both search arms could miss the top 10 entirely in a space full of recent high-importance notes (full analysis in the linked issue).

Also pins the embedding model in the test conftest so the suite is hermetic against operator `.env` overrides.

## Related issue

Closes #163

## Type of change

- [x] Bug fix

## How was this tested?

`tests/test_ranking_dominance.py` — stores 12 recent importance-0.8 chunks plus one exact-match fact; fails before the fix (fact buried), passes after. Full suite + `ruff check .` green locally (py311).