### PR TITLE
deps(python): raise uvicorn and spacy floors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,10 +21,10 @@ dependencies = [
     # reason rather than a feature need.
     "mcp>=2.0.0,<3.0.0",
     "fastapi>=0.141.1,<1",
-    "uvicorn[standard]>=0.52.2,<1",
+    "uvicorn[standard]>=0.52.3,<1",
     "python-multipart>=0.0.32",
     "pydantic>=2.13.4,<3",
-    "spacy>=3.8.14,<4",
+    "spacy>=3.8.15,<4",
     "structlog>=26.1.0,<27",
 ]
 


### PR DESCRIPTION
Combines two dependabot PRs into one change:

- #161 — uvicorn `>=0.52.2` → `>=0.52.3`
- #162 — spacy `>=3.8.14` → `>=3.8.15`

Both are one-line floor bumps to the same file. Merged separately, each one puts the other behind and costs a rebase plus a full CI cycle, so they go together here.

Verified with a `--no-cache` rebuild of the test image so dependencies resolved fresh: uvicorn 0.52.4, spacy 3.8.15. Full suite green (326 passed).

Closes #161
Closes #162
