### PR TITLE
docs: threat model and deployment hardening guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -579,6 +579,7 @@ Memory Vault is MIT-licensed and PRs are welcome. See:
 - [CONTRIBUTING.md](CONTRIBUTING.md) — how to report bugs, suggest features, set up dev environment, coding conventions
 - [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) — Contributor Covenant v2.1
 - [SECURITY.md](SECURITY.md) — reporting vulnerabilities (email `support@mihaibuilds.com`, don't open public issues)
+- [docs/threat-model.md](docs/threat-model.md) — what Memory Vault defends against, what it does not, and how to harden a deployment that goes beyond a single machine
 - [Bug report template](.github/ISSUE_TEMPLATE/bug_report.yml) — includes `memory-vault diagnose` instructions
 - [Feature request template](.github/ISSUE_TEMPLATE/feature_request.yml) — frame the problem before suggesting a solution
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -58,61 +58,11 @@ Reporters are credited by name and link unless they ask not to be. Bounties are 
 - Social engineering, denial-of-service via raw resource exhaustion (Memory Vault is designed for self-hosted single-tenant use).
 - Issues that require physical or admin access to the host machine.
 
-## Threat Model (v1.0)
+## Threat Model
 
-Memory Vault is a **single-tenant, self-hosted** memory database. The threat model reflects that posture — it is not an internet-exposed multi-user SaaS, and the security boundary stops at the host's network.
+Memory Vault is a **single-tenant, self-hosted** memory database. The full threat model — assets, trust boundaries, what is defended, what is explicitly not defended, and hardening guidance for deployments beyond the default model — lives in **[docs/threat-model.md](docs/threat-model.md)**.
 
-### Who's the user?
-
-A developer or hobbyist running Memory Vault on their own machine, homelab, or single-purpose VPS. They control the host, the network, and who has access to the bearer tokens. They're security-aware enough to put it behind a reverse proxy with TLS if exposed beyond localhost.
-
-### Data sensitivity
-
-Memory contents are personal notes, conversation history, and project context — sensitive to the user but not regulated data (no PII subject access requests, no PHI, no payment data). Bearer tokens are the only secret material handled by the application; database credentials are configured via environment, not stored.
-
-### In-scope attacks
-
-| Attack | Defense |
-|---|---|
-| Network MITM between client and API | TLS is the operator's responsibility (reverse proxy in production); bearer tokens are useless without the matching hash in the DB |
-| Stolen bearer token | Rotate via `memory-vault token revoke <prefix>`; `last_used_at` column lets the operator audit suspicious tokens |
-| Brute-force token guessing | Rate limiter (120 req/min per IP, configurable); tokens are 32 random bytes from `secrets.token_urlsafe` (~256 bits of entropy); hash lookup uses `hmac.compare_digest` for constant-time comparison |
-| SQL injection via search queries, space names, file uploads | All raw SQL uses `%s` parameterization (no f-string substitution of user values); Pydantic validates every input at the API boundary; space names match a strict regex (`^[a-z0-9][a-z0-9-]*$`) |
-| XSS in dashboard | React's default escaping is in effect; no `dangerouslySetInnerHTML` anywhere; no `eval` or `new Function` |
-| DoS via oversized inputs | Search queries capped at 8 KB; chat messages capped at 32 KB; ingested text capped at 1 MB; file uploads capped at 25 MB; rate limiter trips at 120 req/min |
-| Stack-trace leakage in error responses | Global `Exception` handler returns generic 500 with no traceback; `psycopg.OperationalError` returns generic 503; full traces go to logs only, correlated by `X-Request-ID` |
-| Credentials leaking via the diagnostic bundle | `memory-vault diagnose` redacts bearer tokens, `mv_*` tokens, password/secret/api_key kv pairs, and known sensitive env vars before producing the zip |
-
-### Out of scope (acknowledged)
-
-| Threat | Why deferred |
-|---|---|
-| Multi-tenant isolation | Memory Vault v1.0 is single-user. PRO (M9) introduces multi-user with `owner_id` enforcement |
-| Encryption at rest | Operator's responsibility — use full-disk encryption on the host, or a managed Postgres with TDE |
-| External penetration audit | Single-maintainer pre-revenue product; revisit post-launch when there's budget |
-| Key Management Service | Bearer tokens are random 32-byte secrets stored as SHA-256 hashes — no rotation infra needed at this scale |
-| Malicious LLM output rendered in dashboard | Chat answers are plain text rendered by React; no HTML/JS execution path. If a future feature renders LLM output as Markdown, it will need an explicit XSS audit |
-| Compromised host machine | Out of scope by design — the host's OS/admin is the trust boundary |
-
-## Security Test Matrix
-
-The repository ships with a re-runnable curl-based pentest at [`scripts/security-pentest.sh`](scripts/security-pentest.sh). It covers:
-
-- **Auth** — missing/wrong-scheme/invalid-token rejection, valid-token success, `/api/health` unauthenticated access
-- **Input validation** — malformed JSON, missing fields, empty queries, oversized payloads (search/ingest), invalid space names
-- **Injection patterns** — SQL injection in search query, Unicode RTL-override in space name, path traversal in upload filename
-- **Rate limit** — manual verification (fire ~140 requests in 60s, observe a 429 with `Retry-After`)
-
-Run before tagging a release:
-
-```bash
-docker compose up -d
-TOKEN=$(memory-vault token create pentest)
-API_URL=http://localhost:8000 API_TOKEN="$TOKEN" bash scripts/security-pentest.sh
-memory-vault token revoke "${TOKEN:0:11}"
-```
-
-Every case must pass before a tag goes out.
+Read it before exposing an instance beyond your own machine.
 
 ## Static Analysis & Dependency Health
 

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -1,0 +1,251 @@
+# Threat model
+
+This document states what Memory Vault protects, what it assumes about its
+environment, and — importantly — what it does **not** defend against. It exists
+so you can decide whether the default deployment fits your situation, and what
+to change if it doesn't.
+
+For reporting a vulnerability, supported versions, and disclosure policy, see
+[SECURITY.md](../SECURITY.md).
+
+Memory Vault is a **single-tenant, self-hosted** application. That assumption
+runs through every decision below. If your deployment breaks that assumption,
+read [Deployments beyond the default model](#deployments-beyond-the-default-model).
+
+---
+
+## Who this is for
+
+A developer or hobbyist running Memory Vault on their own machine, homelab, or
+single-purpose VPS. They control the host, the network, and who holds the bearer
+tokens. The security boundary stops at the host's network.
+
+Memory contents are personal notes, conversation history, and project context —
+sensitive to the operator, but not regulated data. Memory Vault is not built for
+PHI, payment data, or anything carrying subject-access obligations.
+
+---
+
+## What you are protecting
+
+The data in a Memory Vault instance is usually more sensitive than the sum of
+its parts. Individually a note is a note; collectively, an instance is a
+searchable index of what someone has been thinking about, working on, and
+deciding, often over months.
+
+| Asset | Where it lives | Why it matters |
+| --- | --- | --- |
+| Memory content | `chunks.content` in Postgres | The notes, documents and conversations themselves |
+| Embeddings | `chunks.embedding` (pgvector) | Semantic content is partially recoverable from embeddings |
+| Knowledge graph | `entities`, `entity_mentions`, `relationships` | Names, tools, projects and how they connect — a social/work graph |
+| Query history | `query_log` | What was searched for and when, which can be as revealing as the content |
+| API tokens | `api_tokens.token_hash` | SHA-256 hashes; the plaintext is shown once at creation and never stored |
+| Database credentials | Environment variables | Full read/write access to everything above |
+
+---
+
+## Trust boundaries
+
+There are four, and only the first two are enforced by Memory Vault itself.
+
+**1 · Network → REST API.** Every route requires a bearer token except
+`GET /api/health`, which is unauthenticated so container orchestrators can probe
+it without credentials. It returns status, version and the embedding model name —
+no memory content.
+
+**2 · REST API → database.** The application holds one Postgres credential and
+uses it for everything.
+
+**3 · Host → container.** Not currently enforced. See [Known gaps](#known-gaps).
+
+**4 · Memory Vault → LLM endpoint.** Outbound only, to a URL the operator
+supplies. Memory Vault does not restrict where that points; see
+[Outbound requests to the LLM](#outbound-requests-to-the-llm).
+
+---
+
+## In scope — what Memory Vault defends against
+
+| Attack | Defense |
+| --- | --- |
+| Unauthenticated access to memory | Bearer token required on every route except `/api/health`. Tokens are 32 random bytes from `secrets.token_urlsafe`, stored only as SHA-256 hashes |
+| Brute-force token guessing | Token entropy plus a rate limiter (120 req/min per IP, configurable); hash comparison uses `hmac.compare_digest` for constant-time behaviour |
+| Stolen bearer token | Revoke with `memory-vault token revoke <prefix>`; revocation takes effect on the next request. `last_used_at` lets the operator audit suspicious tokens |
+| Network MITM between client and API | Not solved in-application: TLS is the operator's responsibility via a reverse proxy. Tokens are useless without the matching hash in the database |
+| SQL injection | All raw SQL uses `%s` parameter binding — no f-string substitution of user values. Pydantic validates every input at the API boundary; space names must match `^[a-z0-9][a-z0-9-]*$` |
+| Path traversal in static file serving | `_safe_static_path()` sanitises with `os.path.commonpath` and `os.path.realpath`, and rejects malformed input before composition |
+| XSS in the dashboard | React's default escaping; no `dangerouslySetInnerHTML`, no `eval`, no `new Function` anywhere in the web source |
+| Denial of service via oversized inputs | Search queries capped at 8,000 characters; chat messages at 32,000; ingested text at 1,000,000; file uploads stream to disk and abort at 25 MB |
+| Stack-trace leakage in error responses | A global exception handler returns a generic 500 with no traceback; `psycopg.OperationalError` returns a generic 503. Full traces go to logs only, correlated by `X-Request-ID` |
+| Credentials leaking via the diagnostic bundle | `memory-vault diagnose` redacts bearer tokens, `mv_*` values, password/secret/api_key pairs, and known sensitive environment variables before producing the zip |
+
+---
+
+## Out of scope — what Memory Vault does NOT defend against
+
+This section matters more than the one above.
+
+**A stolen API token.** Tokens carry full access to every space in the instance.
+There are no scopes and no per-space permissions. Treat a token as equivalent to
+the whole database.
+
+**Anyone with database access.** Memory content and embeddings are stored in
+plaintext. There is no application-level encryption. Someone who can read the
+Postgres volume can read everything. Use full-disk encryption on the host, or a
+managed Postgres with encryption at rest.
+
+**A malicious operator or a compromised host.** Out of scope by design — the
+host's OS and administrator are the trust boundary.
+
+**Multiple users on one instance.** There is no user model. Spaces are an
+organisational convenience, **not a security boundary** — any valid token reads
+and writes every space. Do not use spaces to separate different people's data.
+
+**Content-based attacks on the LLM.** Text stored in memory is retrieved and
+placed into LLM prompts. Memory Vault does not detect or neutralise prompt
+injection. If you ingest untrusted content, that content can influence what the
+model does when it is later recalled.
+
+**Malicious LLM output rendered in the dashboard.** Chat answers are plain text
+rendered by React, with no HTML or JS execution path. If a future feature renders
+LLM output as Markdown, that will need an explicit XSS review.
+
+**Traffic interception.** The API speaks plain HTTP. There is no built-in TLS;
+terminate it at a reverse proxy.
+
+**Distributed denial of service.** The rate limiter is per-IP and in-memory. It
+resets on restart and is trivially bypassed by a distributed source.
+
+**Deletion recovering storage.** `forget` is a soft delete — the row is marked,
+not removed, so the content remains in the database. Tracked in issue #74.
+
+**Dependency vulnerabilities before an advisory exists.** Report those upstream
+first.
+
+---
+
+## Outbound requests to the LLM
+
+The chat endpoints accept an `llm_url` and send requests to it. **This is a
+product feature, not an oversight**: it is what lets you point Memory Vault at
+your own LM Studio, Ollama, or any OpenAI-compatible endpoint. Memory Vault
+deliberately does not allow-list that URL, because doing so would break the
+configurability that makes it useful.
+
+The consequence is honest: on a deployment where an attacker can reach the API
+with a valid token, that request can be aimed at any address the container can
+reach — including link-local metadata endpoints such as `169.254.169.254` on
+cloud instances.
+
+Under the single-tenant model this is not a privilege escalation, because anyone
+holding a valid token is already the operator. **If your deployment breaks that
+assumption, the correct mitigation is at the network layer, not in the
+application** — see below.
+
+Static analysis flags this pattern (CodeQL `py/partial-ssrf`). Those alerts are
+dismissed as "won't fix" with this rationale rather than being suppressed
+silently — the behaviour is intended and documented here.
+
+Separately, CodeQL reports `py/path-injection` against the static-file handler.
+Those are dismissed as false positives on different grounds: the sanitiser
+described in the in-scope table above is CodeQL's own recommended pattern. That
+one is a defended path, not an accepted risk.
+
+---
+
+## Deployments beyond the default model
+
+The default model assumes the operator is the only user, on their own machine,
+LAN, or single-tenant VM. If you are running on a publicly reachable host, a
+shared network, or a segment with sensitive internal services, apply the
+following.
+
+### API token hygiene
+
+- Issue one token per client rather than sharing a single token.
+- Store tokens in a secret manager or an environment file with restricted
+  permissions — never in shell history or a committed `.env`.
+- Rotate on a schedule you actually keep, and immediately on suspected exposure:
+  `memory-vault token create <name>`, update the client, then
+  `memory-vault token revoke <prefix>`.
+- `memory-vault token list` shows `last_used_at` — use it to find tokens that can
+  be revoked.
+
+### Network scoping
+
+- Bind to `127.0.0.1` and reach it through a reverse proxy, rather than exposing
+  `0.0.0.0:8000` directly. In `docker-compose.yml`, publish as
+  `"127.0.0.1:8000:8000"`.
+- The default compose file also publishes Postgres on `5432`. On any host that is
+  not your own workstation, remove that port mapping — the application reaches
+  the database over the compose network and does not need it.
+- Restrict `API_CORS_ORIGINS` to the origins you actually serve. The default is
+  `*`, which suits local use and is too permissive for a public host.
+
+### Outbound network policy
+
+For deployments where the API is publicly reachable, block egress to link-local
+and internal ranges at the firewall or container network layer — in particular
+`169.254.169.254` on cloud providers. This is the correct mitigation for the
+`llm_url` behaviour described above.
+
+### TLS termination
+
+Put a reverse proxy (nginx, Caddy, Traefik) in front and terminate TLS there.
+Bearer tokens travel in the `Authorization` header; over plain HTTP on an
+untrusted network they are readable in transit.
+
+### Rate limiting
+
+The built-in limiter is per-process and in-memory, sized for a single-tenant box.
+On a public deployment, rate-limit at the proxy layer instead, where it survives
+restarts and sees all workers.
+
+### Database credentials
+
+Change the default `memory_vault` / `memory_vault` credentials in
+`docker-compose.yml`. They are convenient defaults for local use and unsuitable
+anywhere else.
+
+---
+
+## Verifying the posture
+
+The repository ships a re-runnable curl-based pentest at
+[`scripts/security-pentest.sh`](../scripts/security-pentest.sh), covering auth
+rejection paths, input validation, injection patterns (SQL, Unicode RTL-override
+in space names, path traversal in upload filenames), and rate limiting.
+
+```bash
+docker compose up -d
+TOKEN=$(memory-vault token create pentest)
+API_URL=http://localhost:8000 API_TOKEN="$TOKEN" bash scripts/security-pentest.sh
+memory-vault token revoke "${TOKEN:0:11}"
+```
+
+Static analysis and dependency health in CI:
+
+- **CodeQL** ([.github/workflows/codeql.yml](../.github/workflows/codeql.yml)) —
+  security-extended query pack, Python and TypeScript, on push, PR, and weekly.
+- **Dependabot** ([.github/dependabot.yml](../.github/dependabot.yml)) — weekly
+  checks on Python, npm, GitHub Actions, and Docker base images.
+- **Bandit** and **npm audit** — run before each release.
+
+---
+
+## Known gaps
+
+Recorded here rather than left implicit. These are accepted, not hidden.
+
+| Gap | Status |
+| --- | --- |
+| Containers run as root | Being addressed |
+| One database role for both migrations and runtime | Being addressed |
+| API tokens never expire | Being addressed |
+| No per-space or per-scope token permissions | Not planned — spaces are not a security boundary |
+| Memory content stored unencrypted | Not planned — disk encryption is the operator's responsibility |
+| `forget` does not reclaim storage | Tracked in issue #74 |
+| No TLS in the application | Not planned — terminate at a proxy |
+| No external penetration audit | Single-maintainer project; revisit when there is budget |
+
+This table is updated as gaps close; check the version you are running.

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -71,7 +71,6 @@ supplies. Memory Vault does not restrict where that points; see
 | Unauthenticated access to memory | Bearer token required on every route except `/api/health`. Tokens are 32 random bytes from `secrets.token_urlsafe`, stored only as SHA-256 hashes |
 | Brute-force token guessing | Token entropy plus a rate limiter (120 req/min per IP, configurable); hash comparison uses `hmac.compare_digest` for constant-time behaviour |
 | Stolen bearer token | Revoke with `memory-vault token revoke <prefix>`; revocation takes effect on the next request. `last_used_at` lets the operator audit suspicious tokens |
-| Network MITM between client and API | Not solved in-application: TLS is the operator's responsibility via a reverse proxy. Tokens are useless without the matching hash in the database |
 | SQL injection | All raw SQL uses `%s` parameter binding — no f-string substitution of user values. Pydantic validates every input at the API boundary; space names must match `^[a-z0-9][a-z0-9-]*$` |
 | Path traversal in static file serving | `_safe_static_path()` sanitises with `os.path.commonpath` and `os.path.realpath`, and rejects malformed input before composition |
 | XSS in the dashboard | React's default escaping; no `dangerouslySetInnerHTML`, no `eval`, no `new Function` anywhere in the web source |
@@ -83,7 +82,8 @@ supplies. Memory Vault does not restrict where that points; see
 
 ## Out of scope — what Memory Vault does NOT defend against
 
-This section matters more than the one above.
+Each of these is a deliberate boundary, not an oversight. Knowing where they sit
+is what lets you decide whether the default deployment fits your situation.
 
 **A stolen API token.** Tokens carry full access to every space in the instance.
 There are no scopes and no per-space permissions. Treat a token as equivalent to
@@ -118,9 +118,6 @@ resets on restart and is trivially bypassed by a distributed source.
 
 **Deletion recovering storage.** `forget` is a soft delete — the row is marked,
 not removed, so the content remains in the database. Tracked in issue #74.
-
-**Dependency vulnerabilities before an advisory exists.** Report those upstream
-first.
 
 ---
 

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -8,6 +8,11 @@ to change if it doesn't.
 For reporting a vulnerability, supported versions, and disclosure policy, see
 [SECURITY.md](../SECURITY.md).
 
+You do not have to take the claims below on trust. The repository ships a
+re-runnable pentest script that exercises the auth, input-validation and
+injection defenses against a live instance — see
+[Verifying the posture](#verifying-the-posture).
+
 Memory Vault is a **single-tenant, self-hosted** application. That assumption
 runs through every decision below. If your deployment breaks that assumption,
 read [Deployments beyond the default model](#deployments-beyond-the-default-model).
@@ -17,8 +22,11 @@ read [Deployments beyond the default model](#deployments-beyond-the-default-mode
 ## Who this is for
 
 A developer or hobbyist running Memory Vault on their own machine, homelab, or
-single-purpose VPS. They control the host, the network, and who holds the bearer
-tokens. The security boundary stops at the host's network.
+single-purpose VPS, where they control the host, the network, and who holds the
+bearer tokens. The security boundary stops at the host's network.
+
+If that describes your deployment, the defaults are built for you. If it does
+not, the gap is documented rather than assumed away.
 
 Memory contents are personal notes, conversation history, and project context —
 sensitive to the operator, but not regulated data. Memory Vault is not built for
@@ -134,10 +142,13 @@ with a valid token, that request can be aimed at any address the container can
 reach — including link-local metadata endpoints such as `169.254.169.254` on
 cloud instances.
 
-Under the single-tenant model this is not a privilege escalation, because anyone
-holding a valid token is already the operator. **If your deployment breaks that
-assumption, the correct mitigation is at the network layer, not in the
-application** — see below.
+Under the single-tenant model this grants no access the caller did not already
+have, because anyone holding a valid token is already the operator. That
+reasoning holds exactly as long as the token does: **a leaked token turns this
+into a request-forgery primitive against whatever the container can reach.**
+That is the real risk, and it is why the token hygiene and egress guidance below
+are not optional on an exposed host. **The correct mitigation is at the network
+layer, not in the application.**
 
 Static analysis flags this pattern (CodeQL `py/partial-ssrf`). Those alerts are
 dismissed as "won't fix" with this rationale rather than being suppressed
@@ -236,9 +247,9 @@ Recorded here rather than left implicit. These are accepted, not hidden.
 
 | Gap | Status |
 | --- | --- |
-| Containers run as root | Being addressed |
-| One database role for both migrations and runtime | Being addressed |
-| API tokens never expire | Being addressed |
+| Containers run as root | Open |
+| One database role for both migrations and runtime | Open |
+| API tokens never expire | Open |
 | No per-space or per-scope token permissions | Not planned — spaces are not a security boundary |
 | Memory content stored unencrypted | Not planned — disk encryption is the operator's responsibility |
 | `forget` does not reclaim storage | Tracked in issue #74 |


### PR DESCRIPTION
Adds `docs/threat-model.md` and resolves the deployment-hardening documentation request.

## What's in it

- **Assets** — what a Memory Vault instance actually holds, including embeddings and query history, which are easy to overlook when thinking about what leaks
- **Trust boundaries** — four of them, and which two the application actually enforces
- **In scope** — what is defended, with the mechanism named
- **Out of scope** — what is *not* defended, stated plainly: stolen tokens carry full access, spaces are not a security boundary, content is stored unencrypted, prompt injection is not filtered
- **Outbound requests to the LLM** — why `llm_url` is deliberately not allow-listed, and why the mitigation for exposed deployments belongs at the network layer
- **Deployments beyond the default model** — token hygiene, network scoping, outbound policy, TLS termination, rate limiting, database credentials
- **Known gaps** — recorded rather than left implicit

## On SECURITY.md

SECURITY.md already had a threat model section. Shipping a second document would have left two descriptions of the same posture free to drift apart, so its attack tables and the pentest section move into the new file. SECURITY.md keeps reporting policy, supported versions, disclosure, and CI tooling, and points across.

Nothing was dropped in the move — the input caps, XSS posture, stack-trace handling, pentest script and tooling list all survive in the new document.

## Verification

Every factual claim was checked against the code rather than written from memory: token entropy and hashing in `api/deps.py`, the rate-limit default, input caps in `api/schemas.py`, the space-name regex, absence of `dangerouslySetInnerHTML`/`eval` in the web source, redaction key sets in `diagnose.py`, and the dismissed CodeQL alerts via the API.

Two corrections came out of that check: there are six dismissed `py/partial-ssrf` alerts rather than the three originally recorded, and the dismissed `py/path-injection` alerts have a different rationale — a real sanitiser, not accepted risk — so the document says so.

Full suite green (326 passed), `ruff check` and `ruff format --check` clean.

Closes #18
