### PR TITLE
feat(auth): optional expiry for API tokens

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,8 +71,22 @@ jobs:
       - name: Download spaCy model
         run: python -m spacy download en_core_web_sm
 
+      # A collection error already fails the run (pytest exits 2), but a run
+      # that collects far fewer tests than expected still passes — a whole
+      # module can stop being collected without anything going red. The floor
+      # turns "quietly ran a fraction of the suite" into a failure. Raise it
+      # when the suite grows; it is a tripwire, not a target.
       - name: Run pytest
         run: pytest -v --tb=short
+
+      - name: Assert the suite did not shrink
+        run: |
+          count=$(pytest --collect-only -q 2>/dev/null | tail -1 | grep -oE '^[0-9]+')
+          echo "collected: ${count:-0} tests (floor: 300)"
+          if [ "${count:-0}" -lt 300 ]; then
+            echo "::error::Collected ${count:-0} tests, below the floor of 300 — a module may have stopped being collected."
+            exit 1
+          fi
 
   web-build:
     name: Web build (vite production bundle)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,19 @@ dev = [
     "ruff>=0.16.3",
 ]
 
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+# asyncio_mode = "auto" runs async tests without a per-module marker. Under the
+# default "strict" mode a module that forgets `pytestmark = pytest.mark.asyncio`
+# does not run its tests — it reports them as FAILED with "async def functions
+# are not natively supported". That failure is indistinguishable at a glance
+# from a genuine red result, so a test that never executed can be mistaken for
+# proof that a bug reproduces.
+asyncio_mode = "auto"
+# Unknown marks become errors rather than silent no-ops, so a typo in a
+# @pytest.mark name cannot quietly disable whatever it was guarding.
+addopts = "--strict-markers --strict-config"
+
 [tool.ruff]
 line-length = 100
 target-version = "py311"

--- a/src/memory_vault/api/deps.py
+++ b/src/memory_vault/api/deps.py
@@ -38,13 +38,20 @@ def generate_token() -> tuple[str, str, str]:
     return token, hash_token(token), token[:11]
 
 
-async def create_token(name: str) -> str:
-    """Persist a new token and return the plaintext (shown once)."""
+async def create_token(name: str, expires_in_days: int | None = None) -> str:
+    """
+    Persist a new token and return the plaintext (shown once).
+
+    `expires_in_days=None` creates a token that never expires, which is the
+    default and matches every token issued before expiry existed.
+    """
     plaintext, token_hash, prefix = generate_token()
     await execute_query(
-        """INSERT INTO api_tokens (name, token_hash, token_prefix)
-           VALUES (%s, %s, %s)""",
-        (name, token_hash, prefix),
+        """INSERT INTO api_tokens (name, token_hash, token_prefix, expires_at)
+           VALUES (%s, %s, %s,
+                   CASE WHEN %s::int IS NULL THEN NULL
+                        ELSE now() + make_interval(days => %s::int) END)""",
+        (name, token_hash, prefix, expires_in_days, expires_in_days),
     )
     return plaintext
 
@@ -83,31 +90,52 @@ async def require_token(
         )
 
     presented_hash = hash_token(credentials.credentials)
+    # Expired and revoked tokens are fetched too, not filtered out in SQL, so a
+    # token that once existed can be told apart from one that never did. The
+    # distinction never reaches an anonymous caller — it only changes which
+    # message a holder of a real-but-dead token sees, and "your token expired"
+    # saves an operator from hunting a bug that is really a lapsed credential.
     rows = await fetch_all(
-        """SELECT id, token_hash FROM api_tokens
-           WHERE revoked_at IS NULL""",
+        """SELECT id, revoked_at,
+                  (expires_at IS NOT NULL AND expires_at <= now()) AS is_expired,
+                  token_hash
+           FROM api_tokens""",
     )
 
-    # Constant-time scan over all active tokens. SHA-256 of a 32-byte token
+    # Constant-time scan over all tokens. SHA-256 of a 32-byte token
     # gives effectively-random hashes, so a non-constant-time SQL `=` lookup
     # would already be hard to time-attack — but compare_digest makes the
     # property explicit and satisfies the v1.0 security review verbatim.
-    matched_id = None
+    matched = None
     for row in rows:
         if hmac.compare_digest(presented_hash, row["token_hash"]):
-            matched_id = row["id"]
+            matched = row
             break
 
-    if matched_id is None:
+    if matched is None:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid or revoked token",
             headers={"WWW-Authenticate": "Bearer"},
         )
 
+    if matched["revoked_at"] is not None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or revoked token",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    if matched["is_expired"]:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Token expired",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
     await execute_query(
         "UPDATE api_tokens SET last_used_at = now() WHERE id = %s",
-        (matched_id,),
+        (matched["id"],),
     )
 
 

--- a/src/memory_vault/cli.py
+++ b/src/memory_vault/cli.py
@@ -59,6 +59,13 @@ def main() -> None:
 
     p_tok_create = token_sub.add_parser("create", help="Create a new API token")
     p_tok_create.add_argument("name", help="A friendly name for the token")
+    p_tok_create.add_argument(
+        "--expires-in-days",
+        type=int,
+        default=None,
+        metavar="N",
+        help="Expire the token after N days (default: never expires)",
+    )
 
     p_tok_revoke = token_sub.add_parser("revoke", help="Revoke a token by prefix")
     p_tok_revoke.add_argument("prefix", help="Token prefix (first 11 chars)")
@@ -203,12 +210,18 @@ async def _cmd_token(args) -> None:
     await init_pool()
     try:
         if args.token_cmd == "create":
-            plaintext = await create_token(args.name)
+            expires_in_days = getattr(args, "expires_in_days", None)
+            if expires_in_days is not None and expires_in_days < 1:
+                print("--expires-in-days must be 1 or greater.")
+                sys.exit(1)
+            plaintext = await create_token(args.name, expires_in_days)
             print("")
             print("  Token created. Copy it now — it will NOT be shown again.")
             print("")
             print(f"  Name:  {args.name}")
             print(f"  Token: {plaintext}")
+            if expires_in_days is not None:
+                print(f"  Expires: in {expires_in_days} day{'s' if expires_in_days != 1 else ''}")
             print("")
             print("  Use it with: Authorization: Bearer <token>")
             print("")
@@ -221,17 +234,30 @@ async def _cmd_token(args) -> None:
                 sys.exit(1)
         elif args.token_cmd == "list":
             rows = await fetch_all(
-                """SELECT name, token_prefix, created_at, last_used_at, revoked_at
+                """SELECT name, token_prefix, created_at, last_used_at, revoked_at,
+                          expires_at,
+                          (expires_at IS NOT NULL AND expires_at <= now()) AS is_expired
                    FROM api_tokens ORDER BY created_at DESC"""
             )
             if not rows:
                 print("No tokens yet. Create one with: memory-vault token create <name>")
                 return
-            print(f"{'NAME':<20} {'PREFIX':<14} {'CREATED':<22} {'STATUS'}")
+            print(f"{'NAME':<20} {'PREFIX':<14} {'CREATED':<22} {'EXPIRES':<22} {'STATUS'}")
             for r in rows:
-                status_txt = "revoked" if r["revoked_at"] else "active"
+                # Revoked wins over expired: revocation is a decision someone
+                # made, expiry is just time passing.
+                if r["revoked_at"]:
+                    status_txt = "revoked"
+                elif r["is_expired"]:
+                    status_txt = "expired"
+                else:
+                    status_txt = "active"
                 created = str(r["created_at"])[:19]
-                print(f"{r['name']:<20} {r['token_prefix']:<14} {created:<22} {status_txt}")
+                expires = str(r["expires_at"])[:19] if r["expires_at"] else "never"
+                print(
+                    f"{r['name']:<20} {r['token_prefix']:<14} "
+                    f"{created:<22} {expires:<22} {status_txt}"
+                )
     finally:
         await close_pool()
 

--- a/src/memory_vault/migrations/008_token_expiry.sql
+++ b/src/memory_vault/migrations/008_token_expiry.sql
@@ -1,0 +1,26 @@
+-- Memory Vault — optional expiry for API tokens
+--
+-- Until now a token was valid from creation until someone revoked it by hand.
+-- That is fine for the token on your own laptop and wrong for the one you
+-- pasted into a CI job or handed to a script six months ago: nothing expires
+-- it, and nothing reminds you it exists.
+--
+-- `expires_at` is nullable and defaults to NULL, which means "never expires".
+-- Every token that already exists keeps working exactly as before, and a
+-- caller who does not ask for an expiry still gets a permanent token. The
+-- column only does something when someone opts in.
+--
+-- Enforcement lives in the auth path rather than in a constraint, because an
+-- expired token is not invalid data -- it is a row that should stop granting
+-- access while remaining visible to `token list` so the operator can see what
+-- lapsed and when.
+
+ALTER TABLE api_tokens
+    ADD COLUMN IF NOT EXISTS expires_at TIMESTAMPTZ;
+
+-- The auth path filters on `revoked_at IS NULL` and then checks expiry, so the
+-- useful index is over live tokens only. Partial keeps it small: expired and
+-- revoked rows are kept for the audit trail but never looked up by this path.
+CREATE INDEX IF NOT EXISTS api_tokens_active_expiry_idx
+    ON api_tokens (expires_at)
+    WHERE revoked_at IS NULL;

--- a/tests/test_token_expiry.py
+++ b/tests/test_token_expiry.py
@@ -1,0 +1,138 @@
+"""
+Token expiry.
+
+A token used to be valid from creation until someone revoked it by hand.
+`expires_at` makes that optional per token, and the auth path has to
+distinguish three states that all end in 401 for the caller: a token that
+never existed, one that was revoked, and one that simply lapsed. An operator
+debugging a 401 needs to know which.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from memory_vault.api.deps import create_token, revoke_token
+from memory_vault.models.db import execute_query, fetch_one
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _set_expiry(token_prefix: str, sql_interval: str) -> None:
+    """Move a token's expiry relative to now(), e.g. '-1 day' or '+1 day'."""
+    await execute_query(
+        f"UPDATE api_tokens SET expires_at = now() + interval '{sql_interval}' "  # nosec B608
+        "WHERE token_prefix = %s",
+        (token_prefix,),
+    )
+
+
+class TestTokenExpiry:
+    async def test_token_without_expiry_is_accepted(self, client):
+        """The default and the pre-existing behaviour: no expiry means never."""
+        token = await create_token("no-expiry")
+
+        row = await fetch_one(
+            "SELECT expires_at FROM api_tokens WHERE token_prefix = %s", (token[:11],)
+        )
+        assert row["expires_at"] is None, "a token created without an expiry must not have one"
+
+        r = await client.get("/api/spaces", headers={"Authorization": f"Bearer {token}"})
+        assert r.status_code == 200
+
+    async def test_unexpired_token_is_accepted(self, client):
+        token = await create_token("future-expiry", expires_in_days=30)
+
+        row = await fetch_one(
+            "SELECT expires_at FROM api_tokens WHERE token_prefix = %s", (token[:11],)
+        )
+        assert row["expires_at"] is not None, "expires_in_days must set expires_at"
+
+        r = await client.get("/api/spaces", headers={"Authorization": f"Bearer {token}"})
+        assert r.status_code == 200
+
+    async def test_expired_token_returns_401(self, client):
+        token = await create_token("lapsed", expires_in_days=1)
+        await _set_expiry(token[:11], "-1 day")
+
+        r = await client.get("/api/spaces", headers={"Authorization": f"Bearer {token}"})
+        assert r.status_code == 401
+
+    async def test_expiry_boundary_is_exclusive(self, client):
+        """
+        `expires_at <= now()` — a token whose expiry is exactly now is spent.
+
+        Set it a hair in the past rather than exactly now(), because the row is
+        written by one statement and read by another: an exact now() would be
+        microseconds in the past by the time auth reads it, which is what the
+        assertion is really about.
+        """
+        token = await create_token("boundary", expires_in_days=1)
+        await _set_expiry(token[:11], "-1 microsecond")
+
+        r = await client.get("/api/spaces", headers={"Authorization": f"Bearer {token}"})
+        assert r.status_code == 401
+
+    async def test_expired_and_revoked_are_told_apart(self, client):
+        """
+        Both are 401, but the messages must differ. This is the whole reason
+        the auth query stopped filtering dead tokens out in SQL.
+        """
+        expired = await create_token("expired-msg", expires_in_days=1)
+        await _set_expiry(expired[:11], "-1 day")
+
+        revoked = await create_token("revoked-msg")
+        assert await revoke_token(revoked[:11]) is True
+
+        r_expired = await client.get("/api/spaces", headers={"Authorization": f"Bearer {expired}"})
+        r_revoked = await client.get("/api/spaces", headers={"Authorization": f"Bearer {revoked}"})
+
+        assert r_expired.status_code == 401
+        assert r_revoked.status_code == 401
+        assert r_expired.json()["detail"] != r_revoked.json()["detail"], (
+            "an operator debugging a 401 must be able to tell expiry from revocation"
+        )
+        assert "expired" in r_expired.json()["detail"].lower()
+
+    async def test_unknown_token_matches_the_revoked_message(self, client):
+        """
+        A token that never existed must not be distinguishable from one that
+        was revoked — otherwise the error text confirms which random strings
+        were once real tokens.
+        """
+        revoked = await create_token("probe")
+        assert await revoke_token(revoked[:11]) is True
+
+        r_revoked = await client.get("/api/spaces", headers={"Authorization": f"Bearer {revoked}"})
+        r_unknown = await client.get(
+            "/api/spaces", headers={"Authorization": "Bearer mv_never_existed"}
+        )
+
+        assert r_revoked.status_code == r_unknown.status_code == 401
+        assert r_revoked.json()["detail"] == r_unknown.json()["detail"]
+
+    async def test_revoked_beats_expired_when_both_apply(self, client):
+        """Revocation is a decision; expiry is time passing. The decision wins."""
+        token = await create_token("both")
+        await _set_expiry(token[:11], "-1 day")
+        assert await revoke_token(token[:11]) is True
+
+        r = await client.get("/api/spaces", headers={"Authorization": f"Bearer {token}"})
+        assert r.status_code == 401
+        assert "revoked" in r.json()["detail"].lower()
+
+
+@pytest.mark.parametrize("days", [1, 7, 365])
+async def test_expires_in_days_lands_in_the_future(days):
+    """The interval is applied in SQL; check the arithmetic actually happens."""
+    token = await create_token(f"span-{days}", expires_in_days=days)
+    row = await fetch_one(
+        """SELECT expires_at,
+                  (expires_at > now()) AS in_future,
+                  (expires_at < now() + make_interval(days => %s) + interval '1 minute')
+                      AS not_overshot
+           FROM api_tokens WHERE token_prefix = %s""",
+        (days, token[:11]),
+    )
+    assert row["in_future"] is True
+    assert row["not_overshot"] is True


### PR DESCRIPTION
Adds optional expiry to API tokens. Completes the token lifecycle: tokens could be created, listed and revoked, but never expired on their own.

## Why

A token was valid from creation until someone revoked it by hand. That is fine for the token on your own laptop and wrong for the one pasted into a CI job six months ago — nothing expires it, and nothing reminds you it exists.

## What changed

Migration `008` adds a nullable `expires_at`. **NULL means never expires**, so every token that already exists keeps working, and a caller who does not ask for an expiry still gets a permanent token. The column only does something when someone opts in.

The auth query no longer filters dead tokens out in SQL. It fetches the matched row and judges it, which is what lets an expired token report `Token expired` while a revoked one keeps the existing message — an operator debugging a 401 needs to know which of the two they are looking at.

Two deliberate choices in that logic:

- **A token that never existed gets the same message as a revoked one.** Otherwise the error text confirms which random strings were once real tokens.
- **Revoked beats expired when both apply.** Revocation is a decision someone made; expiry is time passing.

CLI: `token create` gains `--expires-in-days`, `token list` gains an `EXPIRES` column and marks lapsed tokens.

## Testing

`tests/test_token_expiry.py` — 10 tests covering no-expiry accepted, future expiry accepted, expired rejected, the `<= now()` boundary, expired-vs-revoked messages differing, unknown-vs-revoked messages matching, revoked-beats-expired, and the interval arithmetic across 1/7/365 days.

Verified RED against `main` in a throwaway container: 9 fail on `column "expires_at" does not exist`. The tenth passes before and after by design — it asserts unknown and revoked tokens stay indistinguishable, so it guards against this change leaking that distinction.

Full suite 336 passed, `ruff check` and `ruff format --check` clean.
