### PR TITLE
feat(db): least-privilege database roles

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,14 @@ services:
       DB_NAME: memory_vault
       DB_USER: memory_vault
       DB_PASSWORD: memory_vault
+      # Least-privilege option: migrations define memory_vault_app /
+      # memory_vault_readonly / memory_vault_migrator group roles. To use them,
+      # create two login roles, grant each one group, then point DB_USER at the
+      # app role and set the two variables below to the migrator. Unset means
+      # migrations run as DB_USER, which is the single-role setup above.
+      # See docs/threat-model.md.
+      # DB_MIGRATION_USER: memory_vault_migrate
+      # DB_MIGRATION_PASSWORD: change_me
       API_HOST: 0.0.0.0
       API_PORT: 8000
       API_AUTH_ENABLED: "true"

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -215,6 +215,46 @@ Change the default `memory_vault` / `memory_vault` credentials in
 `docker-compose.yml`. They are convenient defaults for local use and unsuitable
 anywhere else.
 
+### Least-privilege database roles
+
+By default one database user both creates the schema at start-up and serves
+every request, so anything reaching that connection has rights to change or drop
+your data. Migrations define three group roles you can adopt to narrow that:
+
+| Role | Rights |
+| --- | --- |
+| `memory_vault_app` | `SELECT`/`INSERT`/`UPDATE`/`DELETE`. No schema changes |
+| `memory_vault_readonly` | `SELECT` only — for dashboards, backups, and ad-hoc psql |
+| `memory_vault_migrator` | Schema changes, used only while migrations run |
+
+They are group roles with no login of their own, so nothing changes until you
+opt in. To adopt the split, create two login roles and grant each one group:
+
+```sql
+CREATE ROLE memory_vault_app_login LOGIN PASSWORD 'change_me';
+GRANT memory_vault_app TO memory_vault_app_login;
+
+CREATE ROLE memory_vault_migrate LOGIN PASSWORD 'change_me_too';
+GRANT memory_vault_migrator TO memory_vault_migrate;
+```
+
+Then point the application at the app role and give it the migrator credentials
+for migrations only:
+
+```yaml
+DB_USER: memory_vault_app_login
+DB_PASSWORD: change_me
+DB_MIGRATION_USER: memory_vault_migrate
+DB_MIGRATION_PASSWORD: change_me_too
+```
+
+With `DB_MIGRATION_USER` unset, migrations run as `DB_USER` — the single-role
+setup, unchanged.
+
+One caveat: after adopting the split, run future migrations as the migrator
+role. Tables it creates carry default privileges for the app and read-only
+roles; tables created by some other role do not.
+
 ---
 
 ## Verifying the posture
@@ -248,7 +288,7 @@ Recorded here rather than left implicit. These are accepted, not hidden.
 | Gap | Status |
 | --- | --- |
 | Containers run as root | Open |
-| One database role for both migrations and runtime | Open |
+| One database role for both migrations and runtime | Still the default; opt-in roles available (see above) |
 | API tokens never expire | Open |
 | No per-space or per-scope token permissions | Not planned — spaces are not a security boundary |
 | Memory content stored unencrypted | Not planned — disk encryption is the operator's responsibility |

--- a/src/memory_vault/cli.py
+++ b/src/memory_vault/cli.py
@@ -134,9 +134,15 @@ def main() -> None:
 
 
 async def _cmd_migrate() -> None:
+    from memory_vault.config import settings
     from memory_vault.models.db import close_pool, init_pool, run_migrations
 
-    await init_pool()
+    # Migrations are the only path that needs DDL rights. When
+    # DB_MIGRATION_USER is unset this is the same credential as the runtime
+    # one, which is what every single-role deployment already does.
+    if settings.db_migration_user:
+        print(f"Applying migrations as: {settings.db_migration_user}")
+    await init_pool(conninfo=settings.migration_database_url)
     await run_migrations()
     await close_pool()
     print("Migrations complete.")

--- a/src/memory_vault/config.py
+++ b/src/memory_vault/config.py
@@ -21,6 +21,12 @@ class Settings:
     db_name: str = os.getenv("DB_NAME", "memory_vault")
     db_user: str = os.getenv("DB_USER", "memory_vault")
     db_password: str = os.getenv("DB_PASSWORD", "memory_vault")
+    # Credentials used only while applying migrations. Unset means "use
+    # DB_USER" — the single-credential setup every existing deployment has.
+    # Setting them lets the runtime role drop DDL rights without stopping
+    # migrations from running at start-up.
+    db_migration_user: str | None = os.getenv("DB_MIGRATION_USER") or None
+    db_migration_password: str | None = os.getenv("DB_MIGRATION_PASSWORD") or None
 
     # API
     api_host: str = os.getenv("API_HOST", "0.0.0.0")  # nosec B104 — Memory Vault is designed to run inside a Docker container; binding 0.0.0.0 is required to be reachable from the host. Operators expose only :8000 from compose.
@@ -50,6 +56,31 @@ class Settings:
             dbname=self.db_name,
             user=self.db_user,
             password=self.db_password,
+        )
+
+    @property
+    def migration_database_url(self) -> str:
+        """Conninfo for applying migrations.
+
+        Falls back to the runtime credentials when DB_MIGRATION_USER is unset,
+        so a deployment that never heard of role separation keeps working
+        exactly as before. When it is set, only this connection carries DDL
+        rights and the pool that serves requests does not.
+        """
+        if not self.db_migration_user:
+            return self.database_url
+        return make_conninfo(
+            host=self.db_host,
+            port=self.db_port,
+            dbname=self.db_name,
+            user=self.db_migration_user,
+            # An empty migration password is legitimate (peer/trust auth, or a
+            # .pgpass file), so fall back only when the key is absent entirely.
+            password=(
+                self.db_migration_password
+                if self.db_migration_password is not None
+                else self.db_password
+            ),
         )
 
 

--- a/src/memory_vault/migrations/009_least_privilege_roles.sql
+++ b/src/memory_vault/migrations/009_least_privilege_roles.sql
@@ -1,0 +1,67 @@
+-- Memory Vault — least-privilege database roles
+--
+-- Until now one database user did everything: created the schema at start-up
+-- and then served every request. A bug or an injection reaching that
+-- connection had DDL rights over the whole database, so "drop the chunks
+-- table" was in range of the same credential that answers /api/search.
+--
+-- This migration defines three NOLOGIN group roles and grants each only what
+-- its job needs:
+--
+--   memory_vault_app        DML on the application tables. No DDL.
+--   memory_vault_readonly   SELECT only. For dashboards, backups, and psql
+--                           sessions that have no business writing.
+--   memory_vault_migrator   DDL. Used only while migrations run.
+--
+-- They are GROUP roles, not login users. Nothing here creates a user, sets a
+-- password, or changes who the application connects as: an operator opts in
+-- by creating a login role and granting it one of these. A deployment that
+-- ignores this migration entirely keeps working exactly as it does today,
+-- which is the point — this must not be able to lock anyone out of their own
+-- database.
+--
+-- Adopting it is documented in docs/threat-model.md.
+
+DO $$
+BEGIN
+    -- CREATE ROLE has no IF NOT EXISTS, and this migration has to be safe to
+    -- run against a database where an operator already created these.
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'memory_vault_app') THEN
+        CREATE ROLE memory_vault_app NOLOGIN;
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'memory_vault_readonly') THEN
+        CREATE ROLE memory_vault_readonly NOLOGIN;
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'memory_vault_migrator') THEN
+        CREATE ROLE memory_vault_migrator NOLOGIN;
+    END IF;
+END
+$$;
+
+-- Schema visibility. USAGE lets a role resolve names inside the schema; it
+-- does not grant access to anything in it.
+GRANT USAGE ON SCHEMA public TO memory_vault_app, memory_vault_readonly;
+GRANT USAGE, CREATE ON SCHEMA public TO memory_vault_migrator;
+
+-- Application role: read and write rows, never change their shape.
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO memory_vault_app;
+GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO memory_vault_app;
+
+-- Read-only role.
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO memory_vault_readonly;
+
+-- Migrator role: everything, because it creates the objects the others use.
+GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO memory_vault_migrator;
+GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO memory_vault_migrator;
+
+-- The GRANTs above cover tables that exist right now. Default privileges make
+-- the same true for tables a FUTURE migration creates, so adding a table does
+-- not silently leave the app role unable to read it. These apply to objects
+-- created by the role running this statement, which is why the migrator is the
+-- role that should run migrations from here on.
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+    GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO memory_vault_app;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+    GRANT USAGE, SELECT ON SEQUENCES TO memory_vault_app;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+    GRANT SELECT ON TABLES TO memory_vault_readonly;

--- a/src/memory_vault/models/db.py
+++ b/src/memory_vault/models/db.py
@@ -21,8 +21,16 @@ _pool: AsyncConnectionPool | None = None
 MIGRATIONS_DIR = Path(__file__).resolve().parent.parent / "migrations"
 
 
-async def init_pool(min_size: int = 2, max_size: int = 10) -> AsyncConnectionPool:
+async def init_pool(
+    min_size: int = 2,
+    max_size: int = 10,
+    conninfo: str | None = None,
+) -> AsyncConnectionPool:
     """Create and open the async connection pool.
+
+    ``conninfo`` overrides the runtime credentials; the migration path passes
+    ``settings.migration_database_url`` so DDL runs as a role the serving pool
+    does not use. Everything else leaves it unset.
 
     On any failure during construction, ``open()``, or the post-open
     dimension check, the partially-initialized pool is closed on a
@@ -36,7 +44,7 @@ async def init_pool(min_size: int = 2, max_size: int = 10) -> AsyncConnectionPoo
         return _pool
 
     pool = AsyncConnectionPool(
-        conninfo=settings.database_url,
+        conninfo=conninfo or settings.database_url,
         min_size=min_size,
         max_size=max_size,
         open=False,

--- a/tests/test_least_privilege_roles.py
+++ b/tests/test_least_privilege_roles.py
@@ -1,0 +1,220 @@
+"""
+Least-privilege database roles.
+
+Migration 009 defines three group roles. The property that matters is
+asymmetric: the application role must be able to do everything the running
+application does, and must NOT be able to change the schema. A grant that is
+too generous fails silently — nothing breaks, the protection just is not
+there — so these tests assert the denial as carefully as the permission.
+
+The roles are NOLOGIN groups. These tests create a temporary login role,
+grant it one group, and connect as it, which is exactly how an operator
+adopts the split.
+"""
+
+from __future__ import annotations
+
+import psycopg
+import pytest
+
+from memory_vault.config import settings
+from memory_vault.models.db import fetch_all, fetch_one
+
+
+async def _run_role_ddl(*statements: str) -> None:
+    """
+    Role DDL cannot be parameterised, and `execute_query` forwards a `params`
+    argument that psycopg rejects for these statements, so go through a raw
+    connection. Every value interpolated here is a constant defined in this
+    file, never test input.
+    """
+    from memory_vault.models.db import get_pool
+
+    pool = await get_pool()
+    async with pool.connection() as conn:
+        for stmt in statements:
+            await conn.execute(stmt)  # nosec B608
+        await conn.commit()
+
+
+async def _make_login_role(name: str, group: str) -> None:
+    await _run_role_ddl(
+        f'DROP ROLE IF EXISTS "{name}"',
+        f"CREATE ROLE \"{name}\" LOGIN PASSWORD 'probe_pw'",
+        f'GRANT "{group}" TO "{name}"',
+    )
+
+
+async def _drop_login_role(name: str) -> None:
+    # Privileges granted to the login role must go before the role can be
+    # dropped, or Postgres refuses with "role cannot be dropped because some
+    # objects depend on it".
+    await _run_role_ddl(
+        f'REASSIGN OWNED BY "{name}" TO {settings.db_user}',
+        f'DROP OWNED BY "{name}"',
+        f'DROP ROLE IF EXISTS "{name}"',
+    )
+
+
+def _conninfo_as(user: str) -> str:
+    return psycopg.conninfo.make_conninfo(
+        host=settings.db_host,
+        port=settings.db_port,
+        dbname=settings.db_name,
+        user=user,
+        password="probe_pw",
+    )
+
+
+class TestRolesExist:
+    async def test_all_three_roles_created(self):
+        rows = await fetch_all(
+            """SELECT rolname, rolcanlogin FROM pg_roles
+               WHERE rolname IN ('memory_vault_app',
+                                 'memory_vault_readonly',
+                                 'memory_vault_migrator')
+               ORDER BY rolname"""
+        )
+        assert [r["rolname"] for r in rows] == [
+            "memory_vault_app",
+            "memory_vault_migrator",
+            "memory_vault_readonly",
+        ]
+
+    async def test_roles_cannot_log_in_directly(self):
+        """
+        They are group roles. A role that could log in would be a new
+        credential this migration created without anyone asking for it.
+        """
+        rows = await fetch_all(
+            """SELECT rolname FROM pg_roles
+               WHERE rolname LIKE 'memory_vault_%' AND rolcanlogin"""
+        )
+        assert rows == [], "migration 009 must not create anything that can log in"
+
+    async def test_migration_is_idempotent(self):
+        """Re-running must not fail on roles that already exist."""
+        from pathlib import Path
+
+        from memory_vault.models.db import get_pool
+
+        sql = (
+            Path(__file__).resolve().parent.parent
+            / "src/memory_vault/migrations/009_least_privilege_roles.sql"
+        ).read_text()
+
+        pool = await get_pool()
+        async with pool.connection() as conn:
+            await conn.execute(sql)
+            await conn.commit()
+
+
+class TestAppRolePrivileges:
+    ROLE = "mv_probe_app"
+
+    @pytest.fixture(autouse=True)
+    async def _role(self):
+        await _make_login_role(self.ROLE, "memory_vault_app")
+        yield
+        await _drop_login_role(self.ROLE)
+
+    async def test_app_role_can_read_and_write_rows(self):
+        """Whatever else is true, the application must still work."""
+        async with await psycopg.AsyncConnection.connect(_conninfo_as(self.ROLE)) as conn:
+            await conn.execute(
+                "INSERT INTO memory_spaces (name, description) VALUES (%s, %s)",
+                ("role-probe", "written by the app role"),
+            )
+            cur = await conn.execute(
+                "SELECT name FROM memory_spaces WHERE name = %s", ("role-probe",)
+            )
+            row = await cur.fetchone()
+            assert row is not None, "app role must be able to INSERT then SELECT"
+
+            await conn.execute(
+                "UPDATE memory_spaces SET description = %s WHERE name = %s",
+                ("updated", "role-probe"),
+            )
+            await conn.execute("DELETE FROM memory_spaces WHERE name = %s", ("role-probe",))
+            await conn.commit()
+
+    async def test_app_role_cannot_create_tables(self):
+        async with await psycopg.AsyncConnection.connect(_conninfo_as(self.ROLE)) as conn:
+            with pytest.raises(psycopg.errors.InsufficientPrivilege):
+                await conn.execute("CREATE TABLE mv_probe_ddl (id int)")
+
+    async def test_app_role_cannot_drop_tables(self):
+        """The failure this whole migration exists to prevent."""
+        async with await psycopg.AsyncConnection.connect(_conninfo_as(self.ROLE)) as conn:
+            with pytest.raises(psycopg.errors.InsufficientPrivilege):
+                await conn.execute("DROP TABLE chunks")
+
+        # And the table is still there.
+        row = await fetch_one("SELECT to_regclass('public.chunks') AS t")
+        assert row["t"] is not None, "chunks must survive a denied DROP"
+
+    async def test_app_role_cannot_alter_tables(self):
+        async with await psycopg.AsyncConnection.connect(_conninfo_as(self.ROLE)) as conn:
+            with pytest.raises(psycopg.errors.InsufficientPrivilege):
+                await conn.execute("ALTER TABLE chunks ADD COLUMN mv_probe_col int")
+
+
+class TestReadonlyRolePrivileges:
+    ROLE = "mv_probe_ro"
+
+    @pytest.fixture(autouse=True)
+    async def _role(self):
+        await _make_login_role(self.ROLE, "memory_vault_readonly")
+        yield
+        await _drop_login_role(self.ROLE)
+
+    async def test_readonly_role_can_select(self):
+        async with await psycopg.AsyncConnection.connect(_conninfo_as(self.ROLE)) as conn:
+            cur = await conn.execute("SELECT count(*) AS n FROM memory_spaces")
+            assert (await cur.fetchone()) is not None
+
+    async def test_readonly_role_cannot_insert(self):
+        async with await psycopg.AsyncConnection.connect(_conninfo_as(self.ROLE)) as conn:
+            with pytest.raises(psycopg.errors.InsufficientPrivilege):
+                await conn.execute("INSERT INTO memory_spaces (name) VALUES (%s)", ("ro-probe",))
+
+    async def test_readonly_role_cannot_delete(self):
+        async with await psycopg.AsyncConnection.connect(_conninfo_as(self.ROLE)) as conn:
+            with pytest.raises(psycopg.errors.InsufficientPrivilege):
+                await conn.execute("DELETE FROM memory_spaces")
+
+
+class TestMigrationCredentialFallback:
+    """
+    The fallback is what keeps this from being a breaking change: a deployment
+    that never sets DB_MIGRATION_USER must connect exactly as it did before.
+    """
+
+    def test_unset_migration_user_falls_back_to_runtime_credentials(self):
+        from memory_vault.config import Settings
+
+        s = Settings(db_migration_user=None, db_migration_password=None)
+        assert s.migration_database_url == s.database_url
+
+    def test_set_migration_user_changes_the_connection(self):
+        from memory_vault.config import Settings
+
+        s = Settings(db_migration_user="migrator_login", db_migration_password="pw")
+        assert "migrator_login" in s.migration_database_url
+        assert s.migration_database_url != s.database_url
+
+    def test_migration_user_without_password_reuses_the_runtime_password(self):
+        """
+        Half-configured is the likely operator mistake. Reusing DB_PASSWORD is
+        wrong less often than sending an empty one.
+        """
+        from memory_vault.config import Settings
+
+        s = Settings(
+            db_user="app_login",
+            db_password="shared_pw",
+            db_migration_user="migrator_login",
+            db_migration_password=None,
+        )
+        assert "shared_pw" in s.migration_database_url
+        assert "migrator_login" in s.migration_database_url


### PR DESCRIPTION
Adds opt-in least-privilege database roles.

## The problem

One database user both created the schema at start-up and served every request. Anything reaching that connection had rights to change or drop the schema — `DROP TABLE chunks` was in range of the same credential that answers `/api/search`.

## What this adds

Migration 009 defines three **NOLOGIN group roles**:

| Role | Rights |
| --- | --- |
| `memory_vault_app` | `SELECT`/`INSERT`/`UPDATE`/`DELETE`. No schema changes |
| `memory_vault_readonly` | `SELECT` only |
| `memory_vault_migrator` | Schema changes, used only while migrations run |

Default privileges are set alongside the grants, so tables created by future migrations carry the same rights rather than silently being unreadable by the app role.

`DB_MIGRATION_USER` / `DB_MIGRATION_PASSWORD` point migrations at a separate role.

## This changes nothing unless you opt in

The roles cannot log in. Nothing here creates a user, sets a password, or changes who the application connects as. With `DB_MIGRATION_USER` unset, migrations run as `DB_USER` — exactly what every existing deployment does today. Adoption is documented in `docs/threat-model.md`.

## Verification

Unit tests cover the grants, the denials, migration idempotency, and the credential fallback (13 tests). Because this changes how the application authenticates to its own database, it was also verified against a real Postgres:

- Booted with the split configured — startup logs `Applying migrations as: mv_migrate_login`, then the API serves as the restricted role
- Exercised create-space (201), ingest (200) and search (1 result) through the API as that role
- Confirmed all four destructive operations are denied to it, and the data survives:

```
DROP TABLE chunks               -> ERROR:  must be owner of table chunks
CREATE TABLE evil (id int)      -> ERROR:  permission denied for schema public
ALTER TABLE chunks ADD COLUMN   -> ERROR:  must be owner of table chunks
TRUNCATE chunks                 -> ERROR:  permission denied for table chunks
```

- Booted again **without** `DB_MIGRATION_USER` to confirm the single-role path is unchanged

Full suite 349 passed, `ruff check` and `ruff format --check` clean.
