### PR TITLE
feat(docker): non-root images and a read-only root filesystem

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,27 @@ RUN pip install --no-cache-dir . \
 
 RUN python -m spacy download en_core_web_sm
 
+# The container runs as a non-root user, so put the model caches somewhere
+# that user owns. HF_HOME defaults to /root/.cache, which is unreadable to
+# anyone else and unwritable under a read-only root filesystem.
+ENV HF_HOME=/opt/model-cache/huggingface \
+    SENTENCE_TRANSFORMERS_HOME=/opt/model-cache/sentence-transformers
+
+# Download the embedding model at BUILD time. Without this the first request
+# after every container start reaches out to huggingface.co and writes into
+# the cache — which fails outright when the root filesystem is read-only, and
+# makes a cold start depend on the network. ~88MB on a ~2.3GB image.
+RUN python -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('all-MiniLM-L6-v2')"
+
+# Non-root. Everything the process writes at runtime is either a mounted
+# volume (/var/log/memory-vault), a tmpfs (/tmp, for streamed uploads), or
+# read-only (the model cache above), so the image itself never needs to be
+# writable — see docker-compose.yml for the read_only + tmpfs setup.
+RUN useradd --system --uid 10001 --create-home --home-dir /home/memoryvault memoryvault \
+    && chown -R memoryvault:memoryvault /app /var/log/memory-vault /opt/model-cache
+
+USER memoryvault
+
 EXPOSE 8000
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=90s --retries=3 \

--- a/Dockerfile.mcp
+++ b/Dockerfile.mcp
@@ -26,5 +26,20 @@ COPY src/ ./src/
 RUN pip install --no-cache-dir . \
     && python -m spacy download en_core_web_sm
 
+# Model caches must live somewhere the non-root user owns; HF_HOME defaults to
+# /root/.cache, which that user can neither read nor write.
+ENV HF_HOME=/opt/model-cache/huggingface \
+    SENTENCE_TRANSFORMERS_HOME=/opt/model-cache/sentence-transformers
+
+# Bake the embedding model in at build time. An MCP server is launched by a
+# client on demand, so a first-run download would put a network fetch in the
+# path of the user's first recall — and fail outright on a read-only rootfs.
+RUN python -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('all-MiniLM-L6-v2')"
+
+RUN useradd --system --uid 10001 --create-home --home-dir /home/memoryvault memoryvault \
+    && chown -R memoryvault:memoryvault /app /opt/model-cache
+
+USER memoryvault
+
 # stdio MCP server — no port exposed, no healthcheck (stdio has no HTTP surface)
 ENTRYPOINT ["python", "-m", "memory_vault.mcp"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,18 @@ services:
       API_CORS_ORIGINS: "*"
       API_RATE_LIMIT_PER_MIN: "120"
       LOG_LEVEL: "INFO"
+    # The image runs as a non-root user (uid 10001) and needs nothing in its
+    # own filesystem at runtime: the embedding model is baked in at build time,
+    # logs go to the volume below, and streamed uploads go to the tmpfs. That
+    # makes a read-only root filesystem practical rather than aspirational.
+    read_only: true
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    tmpfs:
+      # File uploads are streamed to a tempfile before ingestion.
+      - /tmp
     volumes:
       - app_logs:/var/log/memory-vault
 

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -64,7 +64,13 @@ no memory content.
 **2 · REST API → database.** The application holds one Postgres credential and
 uses it for everything.
 
-**3 · Host → container.** Not currently enforced. See [Known gaps](#known-gaps).
+**3 · Host → container.** The images run as a non-root user (uid 10001) and the
+shipped compose file gives them a read-only root filesystem, drops all Linux
+capabilities, and sets `no-new-privileges`. Nothing is written inside the
+container at runtime: the embedding model is baked in at build time, logs go to
+a mounted volume, and streamed uploads go to a tmpfs. This narrows what a
+process that escapes the application can do; it does not contain an attacker who
+has the host.
 
 **4 · Memory Vault → LLM endpoint.** Outbound only, to a URL the operator
 supplies. Memory Vault does not restrict where that points; see
@@ -287,7 +293,7 @@ Recorded here rather than left implicit. These are accepted, not hidden.
 
 | Gap | Status |
 | --- | --- |
-| Containers run as root | Open |
+| Containers run as root | Closed — non-root (uid 10001), read-only rootfs, all capabilities dropped |
 | One database role for both migrations and runtime | Still the default; opt-in roles available (see above) |
 | API tokens never expire | Open |
 | No per-space or per-scope token permissions | Not planned — spaces are not a security boundary |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,10 @@ dev = [
     "pytest-asyncio>=1.4.0",
     "httpx>=0.28.1",
     "ruff>=0.16.3",
+    # Used by the container-hardening tests to read docker-compose.yml. It
+    # arrives transitively today; declaring it means a dependency bump cannot
+    # silently take the test suite with it.
+    "pyyaml>=6.0.3",
 ]
 
 [tool.pytest.ini_options]

--- a/tests/test_container_hardening.py
+++ b/tests/test_container_hardening.py
@@ -1,0 +1,106 @@
+"""
+Container hardening properties.
+
+These assert the shape of the Dockerfiles and the shipped compose file rather
+than a running container — the runtime behaviour is verified by actually
+booting the image, which does not belong in the unit suite. What these catch is
+the silent regression: someone adds a RUN step after USER, or drops the
+read_only flag while debugging, and nothing else notices.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO = Path(__file__).resolve().parent.parent
+DOCKERFILES = ["Dockerfile", "Dockerfile.mcp"]
+
+
+def _lines(name: str) -> list[str]:
+    return (REPO / name).read_text().splitlines()
+
+
+@pytest.mark.parametrize("dockerfile", DOCKERFILES)
+def test_image_switches_to_a_non_root_user(dockerfile):
+    directives = [ln.strip() for ln in _lines(dockerfile) if ln.strip().startswith("USER ")]
+    assert directives, f"{dockerfile} must switch to a non-root USER"
+    assert not directives[-1].split()[1].startswith("root"), f"{dockerfile} ends up running as root"
+
+
+@pytest.mark.parametrize("dockerfile", DOCKERFILES)
+def test_nothing_runs_after_the_user_switch(dockerfile):
+    """
+    A RUN placed after USER either fails on a read-only path or quietly writes
+    files owned by the wrong user. Keeping the switch last makes that ordering
+    mistake impossible to introduce accidentally.
+    """
+    lines = [ln.strip() for ln in _lines(dockerfile)]
+    user_at = max(i for i, ln in enumerate(lines) if ln.startswith("USER "))
+    after = [ln for ln in lines[user_at + 1 :] if ln.startswith("RUN ")]
+    assert after == [], f"{dockerfile} has RUN steps after USER: {after}"
+
+
+@pytest.mark.parametrize("dockerfile", DOCKERFILES)
+def test_model_cache_is_redirected_off_root_home(dockerfile):
+    """
+    HF_HOME defaults to /root/.cache, which a non-root user can neither read
+    nor write. Without redirecting it the image starts and then fails on the
+    first embedding call.
+    """
+    # Directives only — the comment above HF_HOME names /root/.cache to explain
+    # what is being avoided, and matching prose would fail on the explanation
+    # rather than on the configuration.
+    directives = [
+        ln.strip() for ln in _lines(dockerfile) if not ln.strip().startswith("#") and ln.strip()
+    ]
+    body = "\n".join(directives)
+    assert "HF_HOME=" in body, f"{dockerfile} must set HF_HOME"
+    assert "/root/.cache" not in body, f"{dockerfile} still points a cache at /root"
+
+
+@pytest.mark.parametrize("dockerfile", DOCKERFILES)
+def test_embedding_model_is_baked_in_at_build_time(dockerfile):
+    """
+    Without this the first request after every start downloads the model —
+    which fails outright on a read-only root filesystem, and otherwise puts a
+    network fetch in the path of the user's first query.
+    """
+    build_steps = [ln for ln in _lines(dockerfile) if ln.strip().startswith("RUN ")]
+    assert any("SentenceTransformer(" in ln for ln in build_steps), (
+        f"{dockerfile} must download the embedding model in a RUN step at build time"
+    )
+
+
+@pytest.fixture
+def app_service():
+    compose = yaml.safe_load((REPO / "docker-compose.yml").read_text())
+    return compose["services"]["app"]
+
+
+class TestComposeHardening:
+    def test_root_filesystem_is_read_only(self, app_service):
+        assert app_service.get("read_only") is True
+
+    def test_all_capabilities_are_dropped(self, app_service):
+        assert app_service.get("cap_drop") == ["ALL"]
+
+    def test_privilege_escalation_is_blocked(self, app_service):
+        assert "no-new-privileges:true" in (app_service.get("security_opt") or [])
+
+    def test_tmp_is_writable_for_streamed_uploads(self, app_service):
+        """
+        File ingestion streams to a tempfile. With a read-only rootfs and no
+        tmpfs, upload returns 500 while everything else keeps working — the
+        kind of partial break that survives a smoke test.
+        """
+        tmpfs = app_service.get("tmpfs") or []
+        assert any(entry.split(":")[0] == "/tmp" for entry in tmpfs), (
+            "read_only rootfs requires a tmpfs at /tmp or file upload breaks"
+        )
+
+    def test_logs_still_have_a_writable_destination(self, app_service):
+        volumes = app_service.get("volumes") or []
+        assert any("/var/log/memory-vault" in v for v in volumes)


### PR DESCRIPTION
Both images ran as root, and the shipped compose gave the container a writable root filesystem and every Linux capability.

## The blocker was the embedding model

It was not in the image. The first request after every start downloaded ~88MB into `/root/.cache` — a path a non-root user cannot read, and that nothing can write under a read-only root filesystem. So non-root and read-only were not independently achievable; the download had to go first.

It is now fetched at build time. That also takes a network round trip out of the path of a user's first query, and makes a cold start deterministic. Cost is ~88MB on a ~2.3GB image.

## What changed

**Both images**: create a system user (uid 10001), redirect `HF_HOME` and `SENTENCE_TRANSFORMERS_HOME` to a path that user owns, and `USER` as the final step.

**Compose**: `read_only: true`, `cap_drop: [ALL]`, `no-new-privileges:true`, and a `tmpfs` at `/tmp` — file ingestion streams uploads to a tempfile, so without that, uploads return 500 while everything else keeps working.

Unlike the database roles, this needs no adoption steps, so it is the default rather than a commented-out option.

## Verification

By running the built images, not by reading the files.

Booted under the full restriction set:

- create-space `201`, text ingest `200`, **file upload `200`** (writes the tmpfs), search returned 2 results
- log file written to the volume, owned by `memoryvault`
- `touch /app/evil` and `touch /usr/local/evil` → `Read-only file system`
- `id` → `uid=10001(memoryvault)`; inspect confirms `CapDrop=[ALL] ReadonlyRootfs=true`
- model loads with `HF_HUB_OFFLINE=1` — proving no network in the request path

The MCP image was driven over stdio under the same restrictions and returned all five tools with `"status": "online"`, `"database": "connected"`.

## Tests

`tests/test_container_hardening.py` — 13 tests asserting the Dockerfile and compose properties, so a later edit cannot silently revert them. One catches an ordering mistake specifically: a `RUN` after `USER` either fails on a read-only path or writes files owned by the wrong user.

`pyyaml` moves from transitive to declared dev dependency, since these tests parse `docker-compose.yml`.

Full suite 362 passed, `ruff check` and `ruff format --check` clean.
