### PR TITLE
perf(docker): stop storing the embedding model twice

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,20 +45,25 @@ RUN python -m spacy download en_core_web_sm
 ENV HF_HOME=/opt/model-cache/huggingface \
     SENTENCE_TRANSFORMERS_HOME=/opt/model-cache/sentence-transformers
 
-# Download the embedding model at BUILD time. Without this the first request
-# after every container start reaches out to huggingface.co and writes into
-# the cache — which fails outright when the root filesystem is read-only, and
-# makes a cold start depend on the network. ~88MB on a ~2.3GB image.
-RUN python -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('all-MiniLM-L6-v2')"
-
 # Non-root. Everything the process writes at runtime is either a mounted
 # volume (/var/log/memory-vault), a tmpfs (/tmp, for streamed uploads), or
-# read-only (the model cache above), so the image itself never needs to be
+# read-only (the model cache below), so the image itself never needs to be
 # writable — see docker-compose.yml for the read_only + tmpfs setup.
+#
+# The switch happens BEFORE the model download on purpose: a `chown -R` after
+# it rewrites every model file into a new layer, storing the whole ~92MB cache
+# twice. Downloading as the owning user avoids that.
 RUN useradd --system --uid 10001 --create-home --home-dir /home/memoryvault memoryvault \
+    && mkdir -p /opt/model-cache \
     && chown -R memoryvault:memoryvault /app /var/log/memory-vault /opt/model-cache
 
 USER memoryvault
+
+# Download the embedding model at BUILD time. Without this the first request
+# after every container start reaches out to huggingface.co and writes into
+# the cache — which fails outright when the root filesystem is read-only, and
+# makes a cold start depend on the network. ~92MB on a ~2.3GB image.
+RUN python -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('all-MiniLM-L6-v2')"
 
 EXPOSE 8000
 

--- a/Dockerfile.mcp
+++ b/Dockerfile.mcp
@@ -31,15 +31,19 @@ RUN pip install --no-cache-dir . \
 ENV HF_HOME=/opt/model-cache/huggingface \
     SENTENCE_TRANSFORMERS_HOME=/opt/model-cache/sentence-transformers
 
+# Create the user BEFORE the model download. A `chown -R` afterwards rewrites
+# every model file into a new layer, storing the whole ~92MB cache twice in the
+# image. Downloading as the owning user avoids that entirely.
+RUN useradd --system --uid 10001 --create-home --home-dir /home/memoryvault memoryvault \
+    && mkdir -p /opt/model-cache \
+    && chown -R memoryvault:memoryvault /app /opt/model-cache
+
+USER memoryvault
+
 # Bake the embedding model in at build time. An MCP server is launched by a
 # client on demand, so a first-run download would put a network fetch in the
 # path of the user's first recall — and fail outright on a read-only rootfs.
 RUN python -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('all-MiniLM-L6-v2')"
-
-RUN useradd --system --uid 10001 --create-home --home-dir /home/memoryvault memoryvault \
-    && chown -R memoryvault:memoryvault /app /opt/model-cache
-
-USER memoryvault
 
 # stdio MCP server — no port exposed, no healthcheck (stdio has no HTTP surface)
 ENTRYPOINT ["python", "-m", "memory_vault.mcp"]

--- a/tests/test_container_hardening.py
+++ b/tests/test_container_hardening.py
@@ -4,8 +4,9 @@ Container hardening properties.
 These assert the shape of the Dockerfiles and the shipped compose file rather
 than a running container — the runtime behaviour is verified by actually
 booting the image, which does not belong in the unit suite. What these catch is
-the silent regression: someone adds a RUN step after USER, or drops the
-read_only flag while debugging, and nothing else notices.
+the silent regression: someone re-adds a `chown` after the user switch, moves
+the model download back before it (which quietly doubles the image's model
+layer), or drops the read_only flag while debugging, and nothing else notices.
 """
 
 from __future__ import annotations
@@ -31,16 +32,35 @@ def test_image_switches_to_a_non_root_user(dockerfile):
 
 
 @pytest.mark.parametrize("dockerfile", DOCKERFILES)
-def test_nothing_runs_after_the_user_switch(dockerfile):
+def test_no_ownership_fixups_after_the_user_switch(dockerfile):
     """
-    A RUN placed after USER either fails on a read-only path or quietly writes
-    files owned by the wrong user. Keeping the switch last makes that ordering
-    mistake impossible to introduce accidentally.
+    Running a step as the non-root user is fine and often desirable — the model
+    download does it so the files land already owned, instead of being rewritten
+    into a second ~92MB layer by a later `chown -R`.
+
+    What must NOT appear after the switch is another ownership fixup: at that
+    point the build has no privileges to change ownership, so it either fails or
+    silently does nothing.
     """
     lines = [ln.strip() for ln in _lines(dockerfile)]
     user_at = max(i for i, ln in enumerate(lines) if ln.startswith("USER "))
-    after = [ln for ln in lines[user_at + 1 :] if ln.startswith("RUN ")]
-    assert after == [], f"{dockerfile} has RUN steps after USER: {after}"
+    offenders = [ln for ln in lines[user_at + 1 :] if "chown" in ln or ln.startswith("RUN useradd")]
+    assert offenders == [], f"{dockerfile} changes ownership after USER: {offenders}"
+
+
+@pytest.mark.parametrize("dockerfile", DOCKERFILES)
+def test_model_is_downloaded_after_the_user_switch(dockerfile):
+    """
+    Ordering is a size property, not just a permissions one. Downloading the
+    model before `chown -R` stores the whole cache twice — once as root, once
+    re-owned — which cost ~92MB until it was measured.
+    """
+    lines = [ln.strip() for ln in _lines(dockerfile)]
+    user_at = max(i for i, ln in enumerate(lines) if ln.startswith("USER "))
+    model_at = max(i for i, ln in enumerate(lines) if "SentenceTransformer(" in ln)
+    assert model_at > user_at, (
+        f"{dockerfile} downloads the model before USER, duplicating the cache layer"
+    )
 
 
 @pytest.mark.parametrize("dockerfile", DOCKERFILES)


### PR DESCRIPTION
Follow-up to the container hardening: the embedding model was being stored twice in both images.

## What happened

Hardening downloaded the model as root, then ran `chown -R` over the cache to hand it to the non-root user. A `chown -R` rewrites every file it touches into a new layer, so the ~92MB cache ended up in the image twice — once owned by root, once re-owned.

The `useradd` layer measured **93MB** for what should be a few kilobytes of user metadata.

## The fix

Create the user first, switch to it, then download. The files land already owned and there is nothing to re-own.

## Measured

| image | size |
| --- | --- |
| before hardening | 2.2 GB |
| hardened, model stored twice | 2.56 GB |
| hardened, this PR | **2.38 GB** |

180MB recovered. The net cost of hardening is ~180MB rather than ~360MB, and the `useradd` layer drops from 93MB to 1.28MB.

Verified the image still runs as `uid=10001`, the cache is present at 88MB, and the model loads with `HF_HUB_OFFLINE=1` — so neither the hardening nor the offline guarantee regressed.

## On the tests

The original ordering test asserted that nothing runs after `USER`. That was the wrong property: a `RUN` after the switch executes as the non-root user, which is exactly what this change relies on. It now asserts the property that actually matters — no ownership fixup after the switch, since at that point the build has no privileges to perform one.

A second test pins the model download to after the user switch, so the duplicate layer cannot come back without a test failing.

Full suite 364 passed, `ruff check` and `ruff format --check` clean.
