### PR TITLE
ci: scan public text for internal references

### DIFF
--- a/.github/leak-patterns.txt
+++ b/.github/leak-patterns.txt
@@ -1,0 +1,23 @@
+# Patterns that must never appear in a public artifact.
+#
+# One extended regular expression per line. Blank lines and lines starting with
+# '#' are ignored. Matching is case-insensitive.
+#
+# These are internal working references — private notes, planning shorthand, and
+# infrastructure identifiers. None of them are secrets; the harm is that they are
+# meaningless to a reader and expose process detail that belongs in private notes.
+# Credential scanning is a separate concern handled by GitHub secret scanning.
+#
+# Keep this list short and specific. A pattern that fires on ordinary English
+# trains people to ignore the gate, which is worse than not having one.
+
+# Private note-store references
+chunk[[:space:]]+[a-f0-9]{8}
+memory[[:space:]]+chunk[[:space:]]+[a-f0-9]{8}
+
+# Wiki-style links to private notes: [[some-note-name]]
+\[\[[a-z0-9-]+\]\]
+
+# Absolute paths from a development machine
+/Users/[a-z0-9._-]+/
+/home/[a-z0-9._-]+/Projects/

--- a/.github/workflows/leak-gate.yml
+++ b/.github/workflows/leak-gate.yml
@@ -45,6 +45,12 @@ jobs:
           RELEASE_BODY: ${{ github.event.release.body }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        # Actions runs `bash -e` by default, which aborts on the first non-zero
+        # exit. This script inspects grep's exit code deliberately — 1 means "no
+        # match" and is the normal case — so errexit has to be off or the script
+        # dies silently on the first clean pattern. Failure is signalled by
+        # explicit `exit 1` instead.
+        shell: bash --noprofile --norc {0}
         run: |
           set -uo pipefail
 

--- a/.github/workflows/leak-gate.yml
+++ b/.github/workflows/leak-gate.yml
@@ -1,0 +1,122 @@
+name: Leak gate
+
+# Local git hooks catch some of this before a commit, but they only ever see the
+# command line. Anything written through the GitHub API — a PR body from a file,
+# an issue edited in the browser, release notes — never passes a local hook at
+# all. This runs where those artifacts actually land.
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, edited, reopened, synchronize]
+  issues:
+    types: [opened, edited]
+  release:
+    types: [published, edited]
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: read
+
+concurrency:
+  group: leak-gate-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  scan:
+    name: Scan public text for internal references
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Need the base commit to diff against for the changed-files scan.
+          fetch-depth: 0
+
+      - name: Scan
+        env:
+          # Through the environment, never interpolated into the script. A PR
+          # title containing a backtick or $( would otherwise be executed.
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
+          RELEASE_NAME: ${{ github.event.release.name }}
+          RELEASE_BODY: ${{ github.event.release.body }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -uo pipefail
+
+          PATTERNS=".github/leak-patterns.txt"
+
+          # Fail closed. A missing or empty pattern file means the gate is not
+          # doing anything, and a gate that silently does nothing is worse than
+          # no gate — it produces a green check that means nothing.
+          if [ ! -f "$PATTERNS" ]; then
+            echo "::error::$PATTERNS is missing — the leak gate cannot run."
+            exit 1
+          fi
+
+          mapfile -t RULES < <(grep -vE '^[[:space:]]*(#|$)' "$PATTERNS" || true)
+          if [ "${#RULES[@]}" -eq 0 ]; then
+            echo "::error::$PATTERNS defines no patterns — refusing to pass vacuously."
+            exit 1
+          fi
+
+          # Validate every pattern before scanning anything. grep exits 1 for
+          # "no match" and 2 for "bad regex", and only the second is a problem —
+          # so the exit code has to be captured and compared, not just tested for
+          # truthiness. Getting this wrong rejects every valid pattern instead.
+          for rule in "${RULES[@]}"; do
+            printf '' | grep -Eq "$rule" 2>/dev/null
+            status=$?
+            if [ "$status" -gt 1 ]; then
+              echo "::error::Invalid pattern in $PATTERNS: $rule"
+              exit 1
+            fi
+          done
+
+          echo "Loaded ${#RULES[@]} pattern(s)."
+
+          FOUND=0
+
+          scan_text() {
+            local label="$1" text="$2"
+            [ -z "$text" ] && return 0
+            for rule in "${RULES[@]}"; do
+              local hits
+              hits="$(printf '%s' "$text" | grep -Eoi "$rule" | sort -u || true)"
+              if [ -n "$hits" ]; then
+                FOUND=1
+                while IFS= read -r hit; do
+                  echo "::error::$label contains an internal reference: $hit"
+                done <<< "$hits"
+              fi
+            done
+          }
+
+          scan_text "PR title"      "${PR_TITLE:-}"
+          scan_text "PR body"       "${PR_BODY:-}"
+          scan_text "Issue title"   "${ISSUE_TITLE:-}"
+          scan_text "Issue body"    "${ISSUE_BODY:-}"
+          scan_text "Release name"  "${RELEASE_NAME:-}"
+          scan_text "Release body"  "${RELEASE_BODY:-}"
+
+          # Added lines in the diff. Only additions — an existing match should be
+          # fixed deliberately, not block every PR that happens to touch the file.
+          if [ -n "${BASE_SHA:-}" ] && [ -n "${HEAD_SHA:-}" ]; then
+            ADDED="$(git diff "$BASE_SHA" "$HEAD_SHA" --unified=0 \
+                      -- . ':(exclude).github/leak-patterns.txt' \
+                     | grep -E '^\+' | grep -vE '^\+\+\+' || true)"
+            scan_text "Changed files" "$ADDED"
+          fi
+
+          if [ "$FOUND" -ne 0 ]; then
+            echo ""
+            echo "These belong in private notes, not in a public artifact."
+            echo "Patterns live in $PATTERNS."
+            exit 1
+          fi
+
+          echo "No internal references found."


### PR DESCRIPTION
Adds a CI check that scans public text for internal working references.

## Why CI and not a git hook

A local hook only ever sees the command line. Anything written through the GitHub API — a PR body passed as a file, an issue edited in the browser, release notes — never reaches one. The gap was not theoretical: a local hook can fire on a *file path* while the file's contents pass straight through.

This runs where the artifacts actually land: PR titles and bodies, issue titles and bodies, release names and bodies, and the lines a PR adds.

## What it looks for

Patterns live in `.github/leak-patterns.txt` rather than inside the workflow, so they can be reviewed and tested. Currently five: private note identifiers, wiki-style double-bracket note references, and absolute paths from a development machine.

These are not secrets — credential scanning is a separate concern that GitHub secret scanning already covers. They are references that are meaningless to a reader and expose working detail that belongs in private notes.

The list is deliberately short. A pattern that fires on ordinary English trains people to ignore the gate, which is worse than not having one.

## Fail-closed

A missing pattern file, a file containing no patterns, and a malformed regex each fail the run. A gate that silently does nothing produces a green check that means nothing.

Only *added* lines in the diff are scanned — an existing match should be fixed deliberately, not block every PR that happens to touch the file.

Event text is passed through the environment rather than interpolated into the script, so a PR title containing backticks or `$(...)` is data rather than code.

## Verification

Run against `ubuntu:24.04` to match the runner, since shell and grep behaviour differ from a local mac.

**Detection** — catches a note identifier, a double-bracket note reference, and a developer home path, while leaving ordinary prose alone: "this chunk of code handles dedup", "chunks.content with a content_hash", and the threat-model text all pass clean.

**Fail-closed** — missing file, empty file, and a malformed regex (`a{1,2,3}x`) each fail.

That testing found a real bug before merge: the first validation treated any non-zero `grep` exit as a bad pattern, but `grep` exits 1 for "no match" and 2 for "bad regex". It rejected every valid pattern, including the real file — the gate would have failed every PR while looking like it was working.

This PR is its own first live test — and it failed twice before passing, both times usefully.

The first run exited 1 with no output whatsoever. Actions runs steps under `bash -e`, and the validation loop reads `grep`'s exit code on purpose, where 1 means "no match" — the normal result for every valid pattern. Errexit killed the script on the first one. Reproduced in a container, then fixed by overriding the step shell.

The second run worked and caught two matches in this very PR body, where the patterns were quoted as examples. That is a real property of the design: documentation about the gate will legitimately mention what it looks for. The description above now names the patterns rather than spelling them, which is the honest fix — a gate you can talk your way around is not a gate.
