### PR TITLE
fix(logging): do not refuse to start when the log file is unwritable

### DIFF
--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -56,10 +56,20 @@ deciding, often over months.
 
 There are four, and only the first two are enforced by Memory Vault itself.
 
-**1 · Network → REST API.** Every route requires a bearer token except
-`GET /api/health`, which is unauthenticated so container orchestrators can probe
-it without credentials. It returns status, version and the embedding model name —
-no memory content.
+**1 · Network → REST API.** Every route that touches memory requires a bearer
+token. Four paths do not:
+
+- `GET /api/health` — unauthenticated so container orchestrators can probe it
+  without credentials. Returns status, version and the embedding model name.
+- `/docs`, `/redoc`, `/openapi.json` — the interactive API documentation. These
+  describe the API's shape; they expose no memory content, and every operation
+  they document still requires a token to call. They are also exempt from rate
+  limiting.
+
+On a deployment reachable beyond your own machine, the documentation endpoints
+tell an anonymous visitor exactly what the API offers. That is not a
+vulnerability, but it is free reconnaissance — block them at your reverse proxy
+if you would rather not publish it.
 
 **2 · REST API → database.** The application holds one Postgres credential and
 uses it for everything.
@@ -82,7 +92,7 @@ supplies. Memory Vault does not restrict where that points; see
 
 | Attack | Defense |
 | --- | --- |
-| Unauthenticated access to memory | Bearer token required on every route except `/api/health`. Tokens are 32 random bytes from `secrets.token_urlsafe`, stored only as SHA-256 hashes |
+| Unauthenticated access to memory | Bearer token required on every route that reads or writes memory (see the trust boundary above for the four that are open). Tokens are 32 random bytes from `secrets.token_urlsafe`, stored only as SHA-256 hashes, and can be given an expiry |
 | Brute-force token guessing | Token entropy plus a rate limiter (120 req/min per IP, configurable); hash comparison uses `hmac.compare_digest` for constant-time behaviour |
 | Stolen bearer token | Revoke with `memory-vault token revoke <prefix>`; revocation takes effect on the next request. `last_used_at` lets the operator audit suspicious tokens |
 | SQL injection | All raw SQL uses `%s` parameter binding — no f-string substitution of user values. Pydantic validates every input at the API boundary; space names must match `^[a-z0-9][a-z0-9-]*$` |
@@ -184,6 +194,9 @@ following.
   `memory-vault token revoke <prefix>`.
 - `memory-vault token list` shows `last_used_at` — use it to find tokens that can
   be revoked.
+- Give tokens an expiry rather than relying on remembering to revoke them:
+  `memory-vault token create ci --expires-in-days 90`. A token issued without one
+  never lapses.
 
 ### Network scoping
 
@@ -295,7 +308,7 @@ Recorded here rather than left implicit. These are accepted, not hidden.
 | --- | --- |
 | Containers run as root | Closed — non-root (uid 10001), read-only rootfs, all capabilities dropped |
 | One database role for both migrations and runtime | Still the default; opt-in roles available (see above) |
-| API tokens never expire | Open |
+| API tokens never expire | Closed — `memory-vault token create --expires-in-days N`; tokens without an expiry still never lapse |
 | No per-space or per-scope token permissions | Not planned — spaces are not a security boundary |
 | Memory content stored unencrypted | Not planned — disk encryption is the operator's responsibility |
 | `forget` does not reclaim storage | Tracked in issue #74 |

--- a/src/memory_vault/logging_config.py
+++ b/src/memory_vault/logging_config.py
@@ -92,12 +92,25 @@ def configure_logging() -> None:
     root.addHandler(stderr_handler)
 
     if log_file is not None:
-        file_handler = logging.handlers.TimedRotatingFileHandler(
-            log_file,
-            when="midnight",
-            backupCount=7,
-            encoding="utf-8",
-        )
+        try:
+            file_handler = logging.handlers.TimedRotatingFileHandler(
+                log_file,
+                when="midnight",
+                backupCount=7,
+                encoding="utf-8",
+            )
+        except OSError:
+            # The directory exists but the file cannot be opened — a read-only
+            # filesystem with no volume mounted at the log path is the usual
+            # cause. The mkdir above succeeds there because the directory is
+            # baked into the image, so this is the branch that actually catches
+            # it. stderr logging is already attached, and losing the log file is
+            # not a reason to refuse to start.
+            root.warning(
+                "log file %s is not writable; continuing with stderr logging only",
+                log_file,
+            )
+            return
         file_handler.setFormatter(formatter)
         root.addHandler(file_handler)
 

--- a/tests/test_logging_readonly_fallback.py
+++ b/tests/test_logging_readonly_fallback.py
@@ -1,0 +1,94 @@
+"""
+Logging must not be able to stop the process from starting.
+
+A read-only root filesystem with nothing mounted at the log path is a
+supported deployment — it is what the shipped compose file produces if the
+log volume is removed. The log directory is baked into the image, so the
+`mkdir` guard succeeds and the failure lands on opening the file instead.
+Before this was handled, that combination crashed at boot with a traceback
+from inside the logging module.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+
+import pytest
+
+from memory_vault import logging_config
+
+
+@pytest.fixture(autouse=True)
+def _restore_root_logger():
+    """configure_logging() mutates the root logger; put it back afterwards."""
+    root = logging.getLogger()
+    saved = list(root.handlers), root.level
+    yield
+    root.handlers, root.level = list(saved[0]), saved[1]
+
+
+def test_unwritable_log_file_does_not_prevent_startup(tmp_path, monkeypatch):
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    log_file = log_dir / "app.jsonl"
+
+    monkeypatch.setattr(logging_config, "_resolve_log_file", lambda: log_file)
+
+    def _refuse(*args, **kwargs):
+        raise OSError(30, "Read-only file system")
+
+    monkeypatch.setattr(logging.handlers, "TimedRotatingFileHandler", _refuse)
+
+    # The assertion is simply that this returns.
+    logging_config.configure_logging()
+
+
+def test_stderr_logging_survives_an_unwritable_log_file(tmp_path, monkeypatch):
+    """
+    Falling back is only useful if logs still go somewhere. Losing the file and
+    the stream would leave an operator debugging a silent container.
+    """
+    log_file = tmp_path / "logs" / "app.jsonl"
+    log_file.parent.mkdir()
+
+    monkeypatch.setattr(logging_config, "_resolve_log_file", lambda: log_file)
+    monkeypatch.setattr(
+        logging.handlers,
+        "TimedRotatingFileHandler",
+        lambda *a, **k: (_ for _ in ()).throw(OSError(30, "Read-only file system")),
+    )
+
+    logging_config.configure_logging()
+
+    root = logging.getLogger()
+
+    # TimedRotatingFileHandler subclasses StreamHandler, and the patch above
+    # replaced the class anyway, so identify handlers by where they write
+    # rather than by type.
+    assert any(getattr(h, "stream", None) is sys.stderr for h in root.handlers), (
+        "stderr logging must remain after the file handler is refused"
+    )
+    assert not any(hasattr(h, "baseFilename") for h in root.handlers), (
+        "no file handler should be attached when the file could not be opened"
+    )
+    assert not log_file.exists(), "nothing should have been written to the refused path"
+
+
+def test_writable_log_file_still_gets_a_file_handler(tmp_path, monkeypatch):
+    """The fallback must not fire when the path is perfectly usable."""
+    log_file = tmp_path / "logs" / "app.jsonl"
+    monkeypatch.setattr(logging_config, "_resolve_log_file", lambda: log_file)
+
+    logging_config.configure_logging()
+
+    root = logging.getLogger()
+    file_handlers = [
+        h for h in root.handlers if isinstance(h, logging.handlers.TimedRotatingFileHandler)
+    ]
+    assert file_handlers, "a writable path must still produce a file handler"
+    assert Path(file_handlers[0].baseFilename) == log_file
+
+    for h in file_handlers:
+        h.close()


### PR DESCRIPTION
A verification pass over the threat model: walk the finished code against every claim the document makes, rather than trusting that it still describes reality. It turned up two things the document asserted that the code did not do.

## The container could crash at boot

A read-only root filesystem with nothing mounted at the log path exits immediately with a traceback from inside the logging module:

```
OSError: [Errno 30] Read-only file system: '/var/log/memory-vault/app.jsonl'
```

There was already a guard, but it wrapped the `mkdir`. The log directory is baked into the image, so `mkdir` succeeds and the failure lands one line later, on opening the file. The guard could never fire for the case it was written for.

The shipped compose file mounts a volume there, so the default path was fine. Anyone adapting it — dropping the volume, or running the image under their own orchestration with a read-only rootfs — got a crash with no hint about the cause.

Logging now warns and continues on stderr, which was already attached. Losing the log file is not a reason to refuse to start.

Reproduced by removing the log volume from a hardened compose file (`Exited (1)`), then confirmed the same configuration reports `Up (healthy)` after the fix, with the warning in its output.

## The documented auth boundary was wrong

The threat model said every route except `GET /api/health` requires a bearer token. It does not. `/docs`, `/redoc` and `/openapi.json` are unauthenticated *and* exempt from rate limiting.

Confirmed against a running instance with auth enabled:

| path | status |
| --- | --- |
| `/api/health` | 200 |
| `/docs` | 200 |
| `/redoc` | 200 |
| `/openapi.json` | 200 |
| `/api/spaces` | 401 |

This is not a vulnerability — those endpoints expose no memory content, and every operation they document still needs a token to call. But on a host reachable beyond your own machine they hand an anonymous visitor a complete map of the API, and the document should say so rather than quietly overstate the boundary. It now lists all four open paths and suggests blocking the documentation ones at a reverse proxy.

## Also

The token-expiry gap row shipped earlier but was still listed as open; it is now closed, and the rotation guidance mentions `--expires-in-days`.

## Tests

`tests/test_logging_readonly_fallback.py` — startup survives an unwritable log file, stderr logging survives with it, and a writable path still gets a file handler so the fallback cannot fire when it should not.

Verified RED against `main`: 2 fail with the same `OSError: [Errno 30]` seen in the real container, 1 passes (the writable case already worked).

One of those tests was wrong on the first attempt — it identified the file handler with `isinstance`, but `TimedRotatingFileHandler` subclasses `StreamHandler`, so the check could not distinguish them. It now identifies handlers by where they write.

Full suite 367 passed, `ruff check` and `ruff format --check` clean.
