### PR TITLE
fix(api): malformed UUID path values return 422 instead of 500

### DIFF
--- a/src/memory_vault/api/routers/chunks.py
+++ b/src/memory_vault/api/routers/chunks.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from datetime import UTC, datetime
+from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 
@@ -98,7 +99,7 @@ async def list_chunks(
 
 
 @router.get("/chunks/{chunk_id}", response_model=ChunkSummary)
-async def get_chunk(chunk_id: str) -> ChunkSummary:
+async def get_chunk(chunk_id: UUID) -> ChunkSummary:
     row = await fetch_one(
         """SELECT c.id, c.content, c.source, c.speaker, c.importance,
                   c.created_at, c.metadata, ms.name AS space
@@ -112,7 +113,7 @@ async def get_chunk(chunk_id: str) -> ChunkSummary:
 
 
 @router.delete("/chunks/{chunk_id}", response_model=ForgetResponse)
-async def forget_chunk(chunk_id: str) -> ForgetResponse:
+async def forget_chunk(chunk_id: UUID) -> ForgetResponse:
     """Soft-delete a chunk (same behavior as the MCP `forget` tool)."""
     row = await fetch_one(
         "SELECT id, content, metadata FROM chunks WHERE id = %s",
@@ -149,13 +150,16 @@ async def forget_chunk(chunk_id: str) -> ForgetResponse:
     preview = row["content"][:80] + ("..." if len(row["content"]) > 80 else "")
     return ForgetResponse(
         success=True,
-        chunk_id=chunk_id,
+        # The path value is a UUID object now that FastAPI validates it. The
+        # response has always carried a string, and changing that would alter
+        # the API for every existing client.
+        chunk_id=str(chunk_id),
         message=f'Memory forgotten: "{preview}"',
     )
 
 
 @router.post("/chunks/{chunk_id}/move", response_model=ChunkMoveResponse)
-async def move_chunk_endpoint(chunk_id: str, req: ChunkMoveRequest) -> ChunkMoveResponse:
+async def move_chunk_endpoint(chunk_id: UUID, req: ChunkMoveRequest) -> ChunkMoveResponse:
     """Move a chunk into another existing space.
 
     The content and embedding are untouched; the chunk's knowledge-graph
@@ -163,7 +167,9 @@ async def move_chunk_endpoint(chunk_id: str, req: ChunkMoveRequest) -> ChunkMove
     about where the memory lives.
     """
     try:
-        result = await move_chunk(chunk_id, req.target_space)
+        # move_chunk takes the id as a string; FastAPI has already proved the
+        # path value is a well-formed UUID by this point.
+        result = await move_chunk(str(chunk_id), req.target_space)
     except ChunkNotFound as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
     except SpaceNotFound as e:

--- a/src/memory_vault/api/routers/graph.py
+++ b/src/memory_vault/api/routers/graph.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from uuid import UUID
+
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 
 from memory_vault.api.deps import require_token
@@ -95,7 +97,7 @@ async def list_entities(
 
 
 @router.get("/entities/{entity_id}", response_model=EntityDetail)
-async def get_entity(entity_id: str) -> EntityDetail:
+async def get_entity(entity_id: UUID) -> EntityDetail:
     # mention_count reflects only mentions on live (non-forgotten) chunks.
     entity = await fetch_one(
         """SELECT e.id, e.name, e.type, ms.name AS space_name, e.created_at,

--- a/tests/test_uuid_path_validation.py
+++ b/tests/test_uuid_path_validation.py
@@ -1,0 +1,100 @@
+"""
+Malformed UUID path parameters.
+
+The UUID-backed routes declared their identifiers as `str`, so a value like
+`not-a-valid-identifier` reached PostgreSQL, which rejected the comparison and
+left the global handler to report a generic 500. Typing them as `UUID` moves
+the rejection to the route boundary: FastAPI answers 422 without opening a
+database connection at all.
+
+Every route taking a UUID in its path is covered, including
+`POST /chunks/{id}/move`, which shipped after the report and had the same
+defect.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+pytestmark = pytest.mark.asyncio
+
+# An empty segment is deliberately absent: `/api/chunks/` matches the list
+# route and redirects, so it exercises routing rather than UUID validation.
+MALFORMED = [
+    "not-a-valid-identifier",
+    "12345",
+    "../etc/passwd",
+    "00000000-0000-0000-0000-00000000000",  # one digit short
+    "zzzzzzzz-zzzz-zzzz-zzzz-zzzzzzzzzzzz",  # right shape, not hex
+]
+
+
+@pytest.mark.parametrize("bad", MALFORMED)
+async def test_get_chunk_rejects_malformed_uuid(client, auth_headers, bad):
+    r = await client.get(f"/api/chunks/{bad}", headers=auth_headers)
+    assert r.status_code != 500, f"{bad!r} must not produce a server error"
+    assert r.status_code in (404, 422), f"{bad!r} gave {r.status_code}"
+
+
+@pytest.mark.parametrize("bad", MALFORMED)
+async def test_delete_chunk_rejects_malformed_uuid(client, auth_headers, bad):
+    r = await client.delete(f"/api/chunks/{bad}", headers=auth_headers)
+    assert r.status_code != 500, f"{bad!r} must not produce a server error"
+    assert r.status_code in (404, 422), f"{bad!r} gave {r.status_code}"
+
+
+@pytest.mark.parametrize("bad", MALFORMED)
+async def test_move_chunk_rejects_malformed_uuid(client, auth_headers, bad):
+    """Not in the original report — this route shipped later with the same defect."""
+    r = await client.post(
+        f"/api/chunks/{bad}/move",
+        json={"target_space": "somewhere"},
+        headers=auth_headers,
+    )
+    assert r.status_code != 500, f"{bad!r} must not produce a server error"
+    assert r.status_code in (404, 422), f"{bad!r} gave {r.status_code}"
+
+
+@pytest.mark.parametrize("bad", MALFORMED)
+async def test_get_entity_rejects_malformed_uuid(client, auth_headers, bad):
+    r = await client.get(f"/api/graph/entities/{bad}", headers=auth_headers)
+    assert r.status_code != 500, f"{bad!r} must not produce a server error"
+    assert r.status_code in (404, 422), f"{bad!r} gave {r.status_code}"
+
+
+class TestWellFormedIdsStillWork:
+    """
+    The point is to reject malformed input, not to break the valid path. A
+    well-formed UUID that matches nothing must still be a plain 404.
+    """
+
+    async def test_unknown_chunk_is_404_not_422(self, client, auth_headers):
+        missing = str(uuid.uuid4())
+        r = await client.get(f"/api/chunks/{missing}", headers=auth_headers)
+        assert r.status_code == 404
+
+    async def test_unknown_entity_is_404_not_422(self, client, auth_headers):
+        missing = str(uuid.uuid4())
+        r = await client.get(f"/api/graph/entities/{missing}", headers=auth_headers)
+        assert r.status_code == 404
+
+    async def test_real_chunk_still_fetches(self, client, auth_headers):
+        """A round trip through the retyped route, to prove it still resolves."""
+        await client.post("/api/spaces", json={"name": "uuid-probe"}, headers=auth_headers)
+        ingest = await client.post(
+            "/api/ingest/text",
+            json={"text": "A chunk fetched back by its identifier.", "space": "uuid-probe"},
+            headers=auth_headers,
+        )
+        assert ingest.status_code == 200
+
+        listing = await client.get(
+            "/api/chunks", params={"space": "uuid-probe"}, headers=auth_headers
+        )
+        chunk_id = listing.json()["chunks"][0]["chunk_id"]
+
+        fetched = await client.get(f"/api/chunks/{chunk_id}", headers=auth_headers)
+        assert fetched.status_code == 200
+        assert fetched.json()["chunk_id"] == chunk_id


### PR DESCRIPTION
The UUID-backed routes declared their identifiers as `str`, so a value like `not-a-valid-identifier` reached PostgreSQL, which rejected the comparison and left the global exception handler to report a generic 500.

Typing them as `UUID` moves the rejection to the route boundary. FastAPI answers 422 without opening a database connection at all.

## Routes covered

- `GET /api/chunks/{chunk_id}`
- `DELETE /api/chunks/{chunk_id}`
- `GET /api/graph/entities/{entity_id}`
- `POST /api/chunks/{chunk_id}/move` — not in the original report; it shipped later with the same defect

## A regression the change caused, and how it was handled

Retyping the path parameter changes what the handler holds, and three existing tests caught it: `forget_chunk` passed the value straight into `ForgetResponse`, whose `chunk_id` field is a string. The response would have started carrying a serialised UUID instead of the string every existing client expects.

Converted at that boundary rather than loosening the schema — the response shape is part of the API, and widening the type to accept both would have made the change invisible rather than fixed.

The graph route needed no equivalent change: it builds its response from the database row, not from the path value.

## Testing

`tests/test_uuid_path_validation.py` — 23 tests. Five malformed shapes across four routes, plus a group asserting the valid path still behaves: a well-formed but unknown id is still a plain 404, and a real chunk still round-trips through the retyped route.

Verified RED against `main`: 16 fail, every one on `must not produce a server error` — the reported 500 reproducing. Seven pass before and after, which is correct: `../etc/passwd` never matches the route in the first place, so routing rejects it rather than the handler, and the 404 and round-trip cases are the contract this change must not break.

One case was dropped from the parameter list after the first RED run. An empty path segment returns 307, because `/api/chunks/` matches the list route and redirects — that exercises routing, not UUID validation, and asserting on it would have been testing the wrong thing.

Full suite 395 passed, `ruff check` and `ruff format --check` clean.

Reported by @lcj-codex-coder.

Closes #102
