### PR TITLE
fix(config): an empty environment variable uses the default

### DIFF
--- a/src/memory_vault/api/app.py
+++ b/src/memory_vault/api/app.py
@@ -22,6 +22,7 @@ from memory_vault import __version__
 from memory_vault.api.deps import RateLimitMiddleware
 from memory_vault.api.middleware import RequestIDMiddleware
 from memory_vault.api.routers import chat, chunks, graph, health, ingest, search, spaces
+from memory_vault.config import env_int
 from memory_vault.logging_config import configure_logging
 from memory_vault.models.db import close_pool, init_pool
 
@@ -62,7 +63,7 @@ def create_app() -> FastAPI:
         allow_headers=["*"],
     )
 
-    rate_limit = int(os.getenv("API_RATE_LIMIT_PER_MIN", "120"))
+    rate_limit = env_int("API_RATE_LIMIT_PER_MIN", 120)
     app.add_middleware(RateLimitMiddleware, requests_per_minute=rate_limit)
     app.add_middleware(RequestIDMiddleware)
 

--- a/src/memory_vault/config.py
+++ b/src/memory_vault/config.py
@@ -13,14 +13,53 @@ from psycopg.conninfo import make_conninfo
 load_dotenv()
 
 
+class InvalidSetting(ValueError):
+    """A setting was present but could not be read as the type it needs to be."""
+
+
+def env_str(name: str, default: str) -> str:
+    """Read a string setting, treating an empty value as unset.
+
+    `os.getenv` falls back to its default only when the key is absent. Config
+    generated from a manifest emits every declared key, empty where the
+    generator had no value to supply, so present-but-empty is the normal shape
+    of machine-written config rather than an edge case.
+    """
+    value = os.getenv(name)
+    if value is None or not value.strip():
+        return default
+    return value
+
+
+def env_int(name: str, default: int) -> int:
+    """Read an integer setting, treating an empty value as unset.
+
+    A genuinely malformed value fails with the name of the setting and what it
+    received. Without this the process died inside `int()` with a bare
+    "invalid literal for int()" and no indication of which setting was at
+    fault — and it died at import, upstream of the health endpoint and the
+    connection pool's retries, so nothing else could report it either.
+    """
+    raw = os.getenv(name)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        return int(raw.strip())
+    except ValueError:
+        raise InvalidSetting(
+            f"{name} must be an integer, got {raw!r}. "
+            f"Leave it unset or empty to use the default ({default})."
+        ) from None
+
+
 @dataclass(frozen=True)
 class Settings:
     # Database
-    db_host: str = os.getenv("DB_HOST", "localhost")
-    db_port: int = int(os.getenv("DB_PORT", "5432"))
-    db_name: str = os.getenv("DB_NAME", "memory_vault")
-    db_user: str = os.getenv("DB_USER", "memory_vault")
-    db_password: str = os.getenv("DB_PASSWORD", "memory_vault")
+    db_host: str = env_str("DB_HOST", "localhost")
+    db_port: int = env_int("DB_PORT", 5432)
+    db_name: str = env_str("DB_NAME", "memory_vault")
+    db_user: str = env_str("DB_USER", "memory_vault")
+    db_password: str = env_str("DB_PASSWORD", "memory_vault")
     # Credentials used only while applying migrations. Unset means "use
     # DB_USER" — the single-credential setup every existing deployment has.
     # Setting them lets the runtime role drop DDL rights without stopping
@@ -29,17 +68,17 @@ class Settings:
     db_migration_password: str | None = os.getenv("DB_MIGRATION_PASSWORD") or None
 
     # API
-    api_host: str = os.getenv("API_HOST", "0.0.0.0")  # nosec B104 — Memory Vault is designed to run inside a Docker container; binding 0.0.0.0 is required to be reachable from the host. Operators expose only :8000 from compose.
-    api_port: int = int(os.getenv("API_PORT", "8000"))
+    api_host: str = env_str("API_HOST", "0.0.0.0")  # nosec B104 — Memory Vault is designed to run inside a Docker container; binding 0.0.0.0 is required to be reachable from the host. Operators expose only :8000 from compose.
+    api_port: int = env_int("API_PORT", 8000)
 
     # Embedding
-    embedding_model: str = os.getenv("EMBEDDING_MODEL", "all-MiniLM-L6-v2")
-    embedding_dimensions: int = int(os.getenv("EMBEDDING_DIMENSIONS", "384"))
-    embedding_batch_size: int = int(os.getenv("EMBEDDING_BATCH_SIZE", "32"))
+    embedding_model: str = env_str("EMBEDDING_MODEL", "all-MiniLM-L6-v2")
+    embedding_dimensions: int = env_int("EMBEDDING_DIMENSIONS", 384)
+    embedding_batch_size: int = env_int("EMBEDDING_BATCH_SIZE", 32)
 
     # Search
-    rrf_k: int = int(os.getenv("RRF_K", "60"))
-    search_default_limit: int = int(os.getenv("SEARCH_DEFAULT_LIMIT", "10"))
+    rrf_k: int = env_int("RRF_K", 60)
+    search_default_limit: int = env_int("SEARCH_DEFAULT_LIMIT", 10)
 
     @property
     def database_url(self) -> str:

--- a/tests/test_env_setting_parsing.py
+++ b/tests/test_env_setting_parsing.py
@@ -1,0 +1,137 @@
+"""
+Environment settings that are present but empty.
+
+`os.getenv(name, default)` falls back to the default only when the key is
+absent. An empty value is a legitimate value and passed straight through to
+`int()`, so `DB_PORT=""` raised `ValueError: invalid literal for int()` while
+importing `config.py` — upstream of the health endpoint, the pool's retries
+and the startup probes, so nothing could report it.
+
+Config generated from a manifest emits every declared key, empty where the
+generator has no value to supply, which makes present-but-empty the normal
+shape of machine-written config rather than an edge case.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+import pytest
+
+from memory_vault.config import InvalidSetting, env_int, env_str
+
+NUMERIC_SETTINGS = [
+    ("DB_PORT", "db_port", 5432),
+    ("API_PORT", "api_port", 8000),
+    ("EMBEDDING_DIMENSIONS", "embedding_dimensions", 384),
+    ("EMBEDDING_BATCH_SIZE", "embedding_batch_size", 32),
+    ("RRF_K", "rrf_k", 60),
+    ("SEARCH_DEFAULT_LIMIT", "search_default_limit", 10),
+]
+
+_ATTR_FOR = {var: attr for var, attr, _ in NUMERIC_SETTINGS}
+
+
+def _import_config_with(**env: str) -> subprocess.CompletedProcess[str]:
+    """Import config in a fresh process with `env` applied, printing one setting.
+
+    The import has to happen after the environment is set, which rules out
+    monkeypatch: the dataclass captures its defaults when the class is defined.
+    """
+    (var,) = env
+    child_env = {**os.environ, **env}
+    return subprocess.run(  # nosec B603 — fixed argv, no shell, test-only
+        [
+            sys.executable,
+            "-c",
+            f"from memory_vault.config import settings; print(settings.{_ATTR_FOR[var]})",
+        ],
+        env=child_env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+
+class TestEmptyIsTreatedAsUnset:
+    @pytest.mark.parametrize("empty", ["", "   ", "\t", "\n"])
+    def test_env_int_falls_back_on_empty(self, monkeypatch, empty):
+        monkeypatch.setenv("SOME_PORT", empty)
+        assert env_int("SOME_PORT", 5432) == 5432
+
+    @pytest.mark.parametrize("empty", ["", "   "])
+    def test_env_str_falls_back_on_empty(self, monkeypatch, empty):
+        monkeypatch.setenv("SOME_HOST", empty)
+        assert env_str("SOME_HOST", "localhost") == "localhost"
+
+    def test_absent_key_still_falls_back(self, monkeypatch):
+        monkeypatch.delenv("SOME_PORT", raising=False)
+        assert env_int("SOME_PORT", 7) == 7
+        assert env_str("SOME_HOST", "here") == "here"
+
+    @pytest.mark.parametrize("var,attr,default", NUMERIC_SETTINGS)
+    def test_every_numeric_setting_survives_an_empty_value(self, var, attr, default):
+        """
+        The regression itself, exercised the way a user meets it.
+
+        `Settings` is a frozen dataclass, so its field defaults are evaluated
+        once when the class is defined — at import. `monkeypatch.setenv` after
+        that cannot change them, and a test using it would pass whatever the
+        code did. A subprocess is the only honest check here, and it also
+        matches the real failure: the process died while importing config.
+        """
+        result = _import_config_with(**{var: ""})
+        assert result.returncode == 0, f"{var}='' must not crash the import:\n{result.stderr}"
+        assert result.stdout.strip() == str(default), (
+            f"{var}='' should fall back to {default}, got {result.stdout.strip()!r}"
+        )
+
+
+class TestRealValuesStillWin:
+    def test_env_int_reads_a_real_value(self, monkeypatch):
+        monkeypatch.setenv("SOME_PORT", "6543")
+        assert env_int("SOME_PORT", 5432) == 6543
+
+    def test_surrounding_whitespace_is_tolerated(self, monkeypatch):
+        """`DB_PORT=" 5432 "` from a generated .env should not be fatal."""
+        monkeypatch.setenv("SOME_PORT", "  6543  ")
+        assert env_int("SOME_PORT", 5432) == 6543
+
+    def test_env_str_reads_a_real_value(self, monkeypatch):
+        monkeypatch.setenv("SOME_HOST", "db.internal")
+        assert env_str("SOME_HOST", "localhost") == "db.internal"
+
+    @pytest.mark.parametrize("var,attr,_default", NUMERIC_SETTINGS)
+    def test_settings_still_read_configured_values(self, var, attr, _default):
+        """Also a subprocess, for the reason given above."""
+        result = _import_config_with(**{var: "123"})
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.strip() == "123", (
+            f"{var}=123 should be read, got {result.stdout.strip()!r}"
+        )
+
+
+class TestMalformedValuesFailClearly:
+    @pytest.mark.parametrize("bad", ["abc", "5432x", "12.5", "port"])
+    def test_malformed_int_names_the_setting(self, monkeypatch, bad):
+        """
+        A genuinely wrong value should still fail — but with the name of the
+        setting and what it received, not a bare ValueError from inside int().
+        """
+        monkeypatch.setenv("SOME_PORT", bad)
+        with pytest.raises(InvalidSetting) as exc:
+            env_int("SOME_PORT", 5432)
+
+        message = str(exc.value)
+        assert "SOME_PORT" in message, "the message must name the setting"
+        assert repr(bad) in message, "the message must show what was received"
+        assert "5432" in message, "the message must state the default"
+
+    def test_invalid_setting_is_a_valueerror(self):
+        """
+        Callers that already catch ValueError keep working; the subclass only
+        adds a better message.
+        """
+        assert issubclass(InvalidSetting, ValueError)


### PR DESCRIPTION
`os.getenv` falls back to its default only when the key is **absent**. An empty value is a legitimate value and passed straight through to `int()`, so `DB_PORT=""` raised `ValueError: invalid literal for int() with base 10: ''` while importing `config.py`.

That location matters: it fails upstream of the health endpoint's 503, the connection pool's retry path, and the startup probes. All of them assume the process got far enough to reach them.

## Why this is a first-run failure

`server.json` marks all five database settings `isRequired: true`. Tooling that generates a client config from that manifest emits every required key — empty where it has no value to supply. So machine-written config is precisely the shape that breaks, which makes this bite someone evaluating Memory Vault from a registry entry rather than an existing user with a working `.env`.

## The fix

`env_str` and `env_int` treat an empty or whitespace-only value as unset and return the documented default. A genuinely malformed value still fails, but names the setting and shows what it received:

```
InvalidSetting: DB_PORT must be an integer, got 'abc'.
Leave it unset or empty to use the default (5432).
```

`InvalidSetting` subclasses `ValueError`, so anything already catching `ValueError` keeps working.

Seven settings were affected: `DB_PORT`, `API_PORT`, `EMBEDDING_DIMENSIONS`, `EMBEDDING_BATCH_SIZE`, `RRF_K`, `SEARCH_DEFAULT_LIMIT`, and `API_RATE_LIMIT_PER_MIN`.

## On the tests

They run the import in a subprocess rather than using `monkeypatch`. `Settings` is a frozen dataclass, so its field defaults are evaluated once when the class is defined — at import. A `monkeypatch.setenv` after that changes nothing, and a test written that way passes regardless of what the code does.

That is not hypothetical: the first version of these tests used `monkeypatch`, and six of them failed by reading the import-time value. The empty-value cases *passed*, but only because the fallback and the captured default happen to be the same number — they were asserting nothing.

Confirmed by mutation. With `env_int` reverted to `int(os.getenv("DB_PORT", "5432"))` and the image rebuilt, the empty-value test for `DB_PORT` fails and the configured-value test still passes, which is the expected split for a bug that only affects empty input.

Verified against `main` before the fix: each of the six `config.py` settings crashes the import with the same `ValueError` when set to an empty string.

Full suite 422 passed, `ruff check` and `ruff format --check` clean.

Closes #181
