### PR TITLE
fix(adapters): max_words is a hard upper bound

### DIFF
--- a/src/memory_vault/adapters/base.py
+++ b/src/memory_vault/adapters/base.py
@@ -84,8 +84,21 @@ def _split_long_text(
     return chunks
 
 
+def _split_by_words(text: str, max_words: int) -> list[str]:
+    """Split on word boundaries, ignoring punctuation entirely.
+
+    The floor under every other strategy. Paragraph and sentence splitting both
+    need a boundary to cut on, and text can simply not have one — a wall of
+    prose with no blank line and no terminator, minified content, a language
+    this splitter has no rules for. Words always exist, so this always
+    terminates and always respects the cap.
+    """
+    words = text.split()
+    return [" ".join(words[i : i + max_words]) for i in range(0, len(words), max_words)]
+
+
 def _split_by_sentences(text: str, max_words: int) -> list[str]:
-    """Last-resort split by sentence boundaries."""
+    """Split by sentence boundaries, falling back to words when one is oversized."""
     import re
 
     sentences = re.split(r"(?<=[.!?])\s+", text)
@@ -95,6 +108,19 @@ def _split_by_sentences(text: str, max_words: int) -> list[str]:
 
     for sent in sentences:
         sent_wc = _word_count(sent)
+
+        # A single sentence over the cap has no sentence boundary to cut on, so
+        # sentence splitting cannot help it. Previously it was appended whole
+        # and `max_words` stopped being an upper bound — and because the flush
+        # below is guarded on `current` being non-empty, an oversized FIRST
+        # sentence escaped even when more text followed it.
+        if sent_wc > max_words:
+            if current:
+                chunks.append(" ".join(current))
+                current, current_wc = [], 0
+            chunks.extend(_split_by_words(sent, max_words))
+            continue
+
         if current_wc + sent_wc > max_words and current:
             chunks.append(" ".join(current))
             current, current_wc = [], 0

--- a/tests/test_chunk_word_cap.py
+++ b/tests/test_chunk_word_cap.py
@@ -1,0 +1,108 @@
+"""
+`max_words` as a hard upper bound.
+
+Paragraph splitting delegates an oversized paragraph to sentence splitting, and
+sentence splitting had no fallback of its own: a sentence longer than the cap
+was appended whole. The flush was also guarded on the accumulator being
+non-empty, so an oversized *first* sentence escaped even when more text
+followed it.
+
+Word splitting is the floor. Paragraphs and sentences both need a boundary to
+cut on and text can simply not have one — a wall of prose with no blank line
+and no terminator, minified content, a language these rules do not cover.
+Words always exist.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from memory_vault.adapters.base import _split_by_words, _split_long_text, _word_count
+
+MAX = 500
+
+
+def _sizes(chunks: list[str]) -> list[int]:
+    return [_word_count(c) for c in chunks]
+
+
+class TestCapIsNeverExceeded:
+    def test_text_with_no_sentence_boundary(self):
+        """The reported case: 600 words, no terminator anywhere."""
+        chunks = _split_long_text("word " * 600, max_words=MAX)
+        assert len(chunks) > 1, "600 words must not come back as one chunk"
+        assert all(s <= MAX for s in _sizes(chunks)), _sizes(chunks)
+
+    def test_oversized_first_sentence_followed_by_more(self):
+        """
+        Specifically the `and current` guard. With an empty accumulator the
+        flush was skipped, so the first sentence escaped regardless of what
+        came after it.
+        """
+        text = ("word " * 600).strip() + ". " + ("more " * 300)
+        chunks = _split_long_text(text, max_words=MAX)
+        assert all(s <= MAX for s in _sizes(chunks)), _sizes(chunks)
+
+    def test_oversized_paragraph_without_sentences(self):
+        chunks = _split_long_text("x " * 1200, max_words=MAX)
+        assert all(s <= MAX for s in _sizes(chunks)), _sizes(chunks)
+
+    @pytest.mark.parametrize("count", [501, 999, 1000, 2500])
+    def test_various_lengths_stay_within_the_cap(self, count):
+        chunks = _split_long_text("word " * count, max_words=MAX)
+        assert all(s <= MAX for s in _sizes(chunks)), _sizes(chunks)
+
+    def test_no_content_is_lost(self):
+        """Splitting must repartition the words, not drop any."""
+        text = "word " * 1234
+        chunks = _split_long_text(text, max_words=MAX)
+        assert sum(_sizes(chunks)) == 1234
+
+
+class TestOrdinaryTextIsUnchanged:
+    """
+    Every adapter calls this on every ingest, so the risk is not the bug — it
+    is changing how text that already split correctly gets chunked.
+    """
+
+    def test_short_text_returns_one_chunk(self):
+        text = "This is a short paragraph. It has two sentences."
+        assert _split_long_text(text, max_words=MAX) == [text]
+
+    def test_exactly_at_the_cap_is_one_chunk(self):
+        text = ("word " * MAX).strip()
+        assert len(_split_long_text(text, max_words=MAX)) == 1
+
+    def test_normal_prose_splits_on_sentences_not_words(self):
+        """
+        Sentence boundaries must still be preferred. If word splitting had
+        taken over, chunks would end mid-sentence.
+        """
+        chunks = _split_long_text("This is a sentence. " * 200, max_words=MAX)
+        assert all(s <= MAX for s in _sizes(chunks))
+        assert all(c.rstrip().endswith(".") for c in chunks), (
+            "sentence splitting should still cut on sentence ends"
+        )
+
+    def test_paragraph_structure_is_still_preferred(self):
+        """Paragraphs under the cap are merged, not word-split."""
+        text = "\n\n".join(f"Paragraph {i}. " + "word " * 80 for i in range(10))
+        chunks = _split_long_text(text, max_words=MAX)
+        assert all(s <= MAX for s in _sizes(chunks))
+        assert any("\n\n" in c for c in chunks), "paragraph joins should survive"
+
+
+class TestSplitByWords:
+    def test_splits_into_full_sized_pieces(self):
+        chunks = _split_by_words("word " * 1000, 400)
+        assert _sizes(chunks) == [400, 400, 200]
+
+    def test_short_input_is_a_single_chunk(self):
+        assert _split_by_words("a b c", 400) == ["a b c"]
+
+    def test_empty_input_yields_nothing(self):
+        assert _split_by_words("", 400) == []
+
+    def test_collapses_irregular_whitespace(self):
+        """`str.split()` handles runs of spaces, tabs and newlines alike."""
+        assert _split_by_words("a\t\tb\n\nc   d", 2) == ["a b", "c d"]


### PR DESCRIPTION
`max_words` was not an upper bound. Paragraph splitting delegates an oversized paragraph to sentence splitting, and sentence splitting had no fallback of its own — a sentence longer than the cap was appended whole.

The flush was also guarded on the accumulator being non-empty:

```python
if current_wc + sent_wc > max_words and current:
```

With an empty accumulator that check is skipped, so an oversized **first** sentence escaped even when more text followed it.

## The fix

Word splitting becomes the floor under everything else. Paragraphs and sentences both need a boundary to cut on, and text can simply not have one — a wall of prose with no blank line and no terminator, minified content, a language these rules do not cover. Words always exist, so the fallback always terminates and always respects the cap.

Sentence boundaries are still preferred. The word split runs only for a single sentence that is itself over the cap, so text that already split correctly chunks exactly as before.

## The risk worth pinning

All three adapters call this on every ingest at `max_words=500`. The danger in this change is not the bug — it is altering how text that already worked gets chunked, which would quietly change every future ingest.

So `TestOrdinaryTextIsUnchanged` asserts the things that must not move: short text still returns one chunk, text exactly at the cap still returns one chunk, normal prose still cuts on sentence ends rather than mid-sentence, and paragraph joins survive. The pre-existing `test_long_section_split` still passes untouched.

## Verification

Against `main`, before the fix:

| input | result |
| --- | --- |
| 600 words, no terminator | one 600-word chunk |
| oversized first sentence + 300 more words | `[600, 300]` |
| 1200-word paragraph, no sentences | one 1200-word chunk |
| normal prose (control) | `[500, 300]` — already correct |

After: every case respects the cap, and the control is unchanged.

Confirmed by mutation — disabling the word fallback fails seven cap tests while the unchanged-behaviour tests keep passing, which is the split a correct test suite should show.

Full suite 438 passed, `ruff check` and `ruff format --check` clean.

Reported by @lcj-codex-coder.

Closes #103
