### PR TITLE
fix(budget): one oversized result can no longer exceed the token budget

### DIFF
--- a/src/memory_vault/api/routers/chat.py
+++ b/src/memory_vault/api/routers/chat.py
@@ -26,6 +26,7 @@ import logging
 import re
 import time
 from collections.abc import AsyncGenerator
+from dataclasses import replace
 
 import httpx
 from fastapi import APIRouter, Depends
@@ -53,6 +54,7 @@ router = APIRouter(prefix="/api", tags=["chat"], dependencies=[Depends(require_t
 # with 4k-8k context. We target ~6000 tokens to leave headroom for the answer.
 _PROMPT_TOKEN_BUDGET = 6000
 _CHARS_PER_TOKEN = 4  # rough estimate, conservative for English
+_TRUNCATION_SUFFIX = "... [truncated]"
 
 
 def _estimate_tokens(text: str) -> int:
@@ -188,6 +190,24 @@ def _apply_token_budget(
 
     while total_tokens() > _PROMPT_TOKEN_BUDGET and len(results) > 1:
         results.pop()  # drop lowest-similarity tail
+
+    # Dropping stops at one result, deliberately — an answer with no context is
+    # worse than a trimmed one. But that last result was then sent whole
+    # however large it was, so a single big memory could exceed the budget
+    # several times over. Trim its content instead of giving up on the cap.
+    if results and total_tokens() > _PROMPT_TOKEN_BUDGET:
+        overshoot = total_tokens() - _PROMPT_TOKEN_BUDGET
+        keep_chars = (
+            len(results[0].content) - (overshoot * _CHARS_PER_TOKEN) - len(_TRUNCATION_SUFFIX)
+        )
+        results[0] = replace(
+            results[0],
+            content=(
+                results[0].content[:keep_chars] + _TRUNCATION_SUFFIX
+                if keep_chars > 0
+                else _TRUNCATION_SUFFIX
+            ),
+        )
 
     return history, results
 

--- a/src/memory_vault/mcp/server.py
+++ b/src/memory_vault/mcp/server.py
@@ -90,6 +90,27 @@ def _estimate_tokens(text: str) -> int:
     return len(text) // 4
 
 
+_TRUNCATION_SUFFIX = "... [truncated]"
+
+
+def _truncate_to_tokens(text: str, max_tokens: int) -> str:
+    """Cut `text` so that it plus its truncation marker fits in `max_tokens`.
+
+    `_estimate_tokens` is `len(text) // 4`, so a token allowance converts to
+    four times as many characters. The marker is part of what gets sent, so it
+    comes out of the same allowance rather than being added on top — otherwise
+    truncating to the limit still exceeds it.
+    """
+    if max_tokens <= 0:
+        return _TRUNCATION_SUFFIX
+    allowed_chars = max_tokens * 4 - len(_TRUNCATION_SUFFIX)
+    if allowed_chars <= 0:
+        return _TRUNCATION_SUFFIX
+    if len(text) <= allowed_chars:
+        return text
+    return text[:allowed_chars] + _TRUNCATION_SUFFIX
+
+
 def _budget_results(results: list[dict], max_tokens: int) -> tuple[list[dict], bool]:
     """
     Fit results within a token budget.
@@ -107,7 +128,17 @@ def _budget_results(results: list[dict], max_tokens: int) -> tuple[list[dict], b
         content = r["content"]
         entry_tokens = _estimate_tokens(content) + 40
 
-        if tokens_used < full_budget:
+        if tokens_used < full_budget and tokens_used + entry_tokens > max_tokens:
+            # Room by the full-content rule, but this one entry would blow the
+            # whole budget on its own. The first result always satisfies
+            # `tokens_used < full_budget`, so without this a single oversized
+            # memory was admitted whole and the advertised cap meant nothing.
+            truncated = True
+            r_copy = dict(r)
+            r_copy["content"] = _truncate_to_tokens(content, max_tokens - tokens_used - 40)
+            budgeted.append(r_copy)
+            tokens_used += _estimate_tokens(r_copy["content"]) + 40
+        elif tokens_used < full_budget:
             budgeted.append(r)
             tokens_used += entry_tokens
         elif tokens_used < max_tokens:

--- a/tests/test_token_budget_cap.py
+++ b/tests/test_token_budget_cap.py
@@ -1,0 +1,152 @@
+"""
+Token budgets as hard caps.
+
+Both budget helpers could admit one arbitrarily oversized result:
+
+  - MCP `_budget_results` appends a result in full whenever
+    `tokens_used < full_budget`, without comparing that result's size to the
+    remaining budget. The first result always satisfies that condition.
+  - Chat `_apply_token_budget` deliberately keeps at least one result, but
+    never trimmed the one it kept.
+
+Keeping one result is right — an answer with no context is worse than one with
+trimmed context. Sending it whole is not.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from memory_vault.api.routers.chat import (
+    _PROMPT_TOKEN_BUDGET,
+    SYSTEM_PROMPT,
+    _apply_token_budget,
+    _format_context_block,
+)
+from memory_vault.api.routers.chat import _estimate_tokens as chat_tokens
+from memory_vault.mcp.server import _budget_results, _estimate_tokens, _truncate_to_tokens
+from memory_vault.services.search import SearchResult
+
+
+def _result(content: str, similarity: float = 0.9) -> SearchResult:
+    return SearchResult(
+        chunk_id="c1",
+        content=content,
+        similarity=similarity,
+        speaker=None,
+        space="s",
+        source=None,
+        created_at=None,
+        metadata={},
+    )
+
+
+def _chat_prompt_tokens(results: list[SearchResult], question: str = "q") -> int:
+    """Mirror of the estimate inside _apply_token_budget, minus history."""
+    return (
+        chat_tokens(SYSTEM_PROMPT)
+        + chat_tokens(_format_context_block(results))
+        + chat_tokens(question)
+        + 200
+    )
+
+
+class TestMcpBudget:
+    @pytest.mark.parametrize(
+        "size,budget",
+        [(10_000, 200), (100_000, 500), (10_000, 1_000), (5_000, 200)],
+    )
+    def test_single_oversized_result_is_capped(self, size, budget):
+        """The reported case: one huge result against a small budget."""
+        budgeted, truncated = _budget_results([{"content": "x" * size}], max_tokens=budget)
+        used = _estimate_tokens(budgeted[0]["content"]) + 40
+        assert used <= budget, f"{used} tokens exceeds the {budget} budget"
+        assert truncated is True, "the caller must be told content was cut"
+
+    def test_small_result_is_untouched(self):
+        """The fix must not trim results that already fit."""
+        content = "y" * 300
+        budgeted, truncated = _budget_results([{"content": content}], max_tokens=1_000)
+        assert budgeted[0]["content"] == content
+        assert truncated is False
+
+    def test_many_results_stay_within_budget(self):
+        results = [{"content": "z" * 4_000} for _ in range(10)]
+        budgeted, truncated = _budget_results(results, max_tokens=1_000)
+        total = sum(_estimate_tokens(r["content"]) + 40 for r in budgeted)
+        assert total <= 1_000, f"{total} tokens exceeds the 1000 budget"
+        assert truncated is True
+
+    def test_empty_results_are_passed_through(self):
+        assert _budget_results([], max_tokens=200) == ([], False)
+
+
+class TestTruncateToTokens:
+    def test_result_fits_the_allowance(self):
+        out = _truncate_to_tokens("x" * 10_000, 100)
+        assert _estimate_tokens(out) <= 100
+
+    def test_marker_is_inside_the_allowance_not_added_to_it(self):
+        """
+        The marker is part of what gets sent. Counting it separately would mean
+        truncating to the limit and still exceeding it.
+        """
+        out = _truncate_to_tokens("x" * 10_000, 50)
+        assert out.endswith("... [truncated]")
+        assert _estimate_tokens(out) <= 50
+
+    def test_short_text_is_returned_unchanged(self):
+        assert _truncate_to_tokens("short", 100) == "short"
+
+    @pytest.mark.parametrize("allowance", [0, -5])
+    def test_no_allowance_yields_only_the_marker(self, allowance):
+        assert _truncate_to_tokens("x" * 100, allowance) == "... [truncated]"
+
+
+class TestChatBudget:
+    @pytest.mark.parametrize("size", [100_000, 50_000, 30_000])
+    def test_single_oversized_result_is_trimmed(self, size):
+        _, results = _apply_token_budget("q", [], [_result("x" * size)])
+        assert len(results) == 1, "one result should still be kept"
+        assert _chat_prompt_tokens(results) <= _PROMPT_TOKEN_BUDGET
+
+    def test_at_least_one_result_survives(self):
+        """
+        Trimming must not become dropping. An answer with no context at all is
+        worse than one with trimmed context.
+        """
+        _, results = _apply_token_budget("q", [], [_result("x" * 500_000)])
+        assert len(results) == 1
+        assert results[0].content, "the kept result must not be emptied"
+
+    def test_result_that_fits_is_untouched(self):
+        content = "a short memory"
+        _, results = _apply_token_budget("q", [], [_result(content)])
+        assert results[0].content == content
+
+    def test_history_is_still_dropped_before_content_is_cut(self):
+        """
+        Trimming the last result is the final step, not the first. History
+        should go first — it is cheaper to lose than retrieved context.
+        """
+        from memory_vault.api.schemas import ChatMessage
+
+        # Enough history to blow the budget on its own, with a result that
+        # comfortably fits. Dropping the history alone should resolve it.
+        history = [ChatMessage(role="user", content="old " * 8_000)]
+        content = "y" * 4_000
+        kept_history, results = _apply_token_budget("q", history, [_result(content)])
+
+        assert kept_history == [], "history should be dropped first"
+        assert results[0].content == content, "content should not be cut unnecessarily"
+
+    def test_multiple_results_are_dropped_before_trimming(self):
+        """Lowest-similarity results go before the top one gets cut."""
+        results_in = [
+            _result("a" * 8_000, similarity=0.9),
+            _result("b" * 8_000, similarity=0.5),
+            _result("c" * 8_000, similarity=0.1),
+        ]
+        _, results = _apply_token_budget("q", [], results_in)
+        assert _chat_prompt_tokens(results) <= _PROMPT_TOKEN_BUDGET
+        assert results[0].content.startswith("a"), "the top result should be the survivor"


### PR DESCRIPTION
Both token-budget helpers could admit one arbitrarily oversized result, so their advertised budgets were not caps.

## Two paths, failing differently

**MCP `_budget_results`** appends a result in full whenever `tokens_used` is below the full-content threshold, without comparing that result's size to what is left. The first result always satisfies that condition:

```
budget=200  actual=2540  overshoot=13x  truncated=False
```

`truncated` reported `False`, so the caller was not even told content had overrun.

**Chat `_apply_token_budget`** drops results until one remains, then stops — but never trimmed the one it kept:

```
budget=6000  actual=25289  overshoot=4x  kept content length=100000
```

## The fix

Keeping at least one result is correct: an answer with no context is worse than one with trimmed context. Sending it whole is not. Both paths now trim the final result to the remaining allowance.

The truncation marker is counted *inside* the allowance rather than added to it. It is part of what gets sent, so counting it separately would mean trimming to the limit and still exceeding it.

After the fix, both land exactly at budget, and results that already fit are untouched:

| path | input | budget | used |
| --- | --- | --- | --- |
| MCP | 10,000 chars | 200 | 200 |
| MCP | 100,000 chars | 500 | 500 |
| MCP | 300 chars | 200 | 115 (unchanged) |
| Chat | 100,000 chars | 6000 | 5999 |
| Chat | 500 chars | 6000 | 414 (unchanged) |

## Ordering is preserved

Trimming is the last resort, not the first. Two tests pin that: history is still dropped before any content is cut, and lower-similarity results are still dropped before the top result is trimmed.

## Testing

19 tests across both helpers, plus the truncation helper itself — including that the marker fits inside the allowance and that a zero or negative allowance yields only the marker rather than crashing.

Verified RED against `main`: 9 failures with the overshoot quantified in each message (`25040 tokens exceeds the 500 budget`), and 5 passes for the cases that already fit — correct before and after.

Confirmed by mutation: disabling either cap fails the oversized cases while the already-fits tests keep passing.

One of these tests was wrong on the first attempt. `test_history_is_still_dropped_before_content_is_cut` used 8,000 characters of history, which is only ~3,050 tokens against a 6,000 budget — nothing needed dropping, so the assertion was asserting nothing. It now uses enough history to actually exceed the budget.

Full suite 457 passed, `ruff check` and `ruff format --check` clean.

Reported by @lcj-codex-coder.

Closes #99
