### PR TITLE
fix(ingest): uploads record the filename, not the server tempfile

### DIFF
--- a/src/memory_vault/api/routers/ingest.py
+++ b/src/memory_vault/api/routers/ingest.py
@@ -118,7 +118,10 @@ async def ingest_file_endpoint(
 
         try:
             pipeline = IngestionPipeline(max_workers=1)
-            pipeline.enqueue(tmp_path, space_id)
+            # Read from the tempfile, but record the name the user uploaded.
+            # The tempfile is deleted when this request ends, so persisting its
+            # path left every uploaded chunk pointing at something gone.
+            pipeline.enqueue(tmp_path, space_id, source_name=filename)
             stats = await pipeline.run_all()
         except HTTPException:
             raise

--- a/src/memory_vault/services/ingestion.py
+++ b/src/memory_vault/services/ingestion.py
@@ -52,6 +52,11 @@ class IngestionJob:
     priority: int
     file_path: str = field(compare=False)
     space_id: int = field(compare=False)
+    # What to record as the chunk's source. Uploads read from a temporary file
+    # that is deleted when the request ends, so the path they ingest from is
+    # not a durable identifier — the original filename is. None means "use
+    # file_path", which is what CLI and directory ingestion want.
+    source_name: str | None = field(default=None, compare=False)
 
 
 class IngestionPipeline:
@@ -73,8 +78,14 @@ class IngestionPipeline:
         file_path: str,
         space_id: int,
         priority: Priority = Priority.BATCH,
+        source_name: str | None = None,
     ) -> None:
-        job = IngestionJob(priority=priority, file_path=file_path, space_id=space_id)
+        job = IngestionJob(
+            priority=priority,
+            file_path=file_path,
+            space_id=space_id,
+            source_name=source_name,
+        )
         self._queue.put_nowait(job)
         self._stats.queued += 1
 
@@ -129,8 +140,12 @@ class IngestionPipeline:
             logger.warning("Skipping empty file: %s", file_path)
             return
 
+        # Detection reads the real path — it needs the extension of the file
+        # actually on disk. What gets recorded as the source is the logical
+        # name when one was supplied, because an upload's temporary path stops
+        # existing the moment the request ends.
         adapter = detect_adapter(file_path, content=raw)
-        raw_chunks = adapter.parse(raw, source_path=file_path)
+        raw_chunks = adapter.parse(raw, source_path=job.source_name or file_path)
 
         if not raw_chunks:
             logger.warning("No chunks produced from: %s", file_path)

--- a/tests/test_upload_source_name.py
+++ b/tests/test_upload_source_name.py
@@ -1,0 +1,119 @@
+"""
+Uploaded files record the name the user sent, not the server's tempfile.
+
+The upload route streams to a `NamedTemporaryFile` and passed that path to the
+pipeline, so every chunk from an upload stored a `source_file` like
+`/tmp/tmpabcd1234.md` — a path that stops existing the moment the request ends.
+
+The route already validated and kept `file.filename`; it just never reached the
+adapter. The pipeline now carries an optional `source_name` that overrides what
+gets recorded, while detection still reads the real path because it needs the
+extension of the file actually on disk.
+"""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+
+from memory_vault.models.db import fetch_all
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _upload(client, auth_headers, name: str, body: str, space: str):
+    return await client.post(
+        "/api/ingest/file",
+        files={"file": (name, io.BytesIO(body.encode()), "text/markdown")},
+        data={"space": space},
+        headers=auth_headers,
+    )
+
+
+async def _sources(space: str) -> list[str]:
+    rows = await fetch_all(
+        """SELECT DISTINCT c.metadata->>'source_file' AS sf
+           FROM chunks c JOIN memory_spaces ms ON ms.id = c.space_id
+           WHERE ms.name = %s""",
+        (space,),
+    )
+    return sorted(r["sf"] for r in rows if r["sf"])
+
+
+class TestUploadedSourceIsTheOriginalName:
+    async def test_source_is_the_uploaded_filename(self, client, auth_headers):
+        await client.post("/api/spaces", json={"name": "up1"}, headers=auth_headers)
+        resp = await _upload(
+            client, auth_headers, "notes.md", "# Notes\n\nSome content here.", "up1"
+        )
+        assert resp.status_code == 200
+
+        assert await _sources("up1") == ["notes.md"]
+
+    async def test_source_is_not_a_temporary_path(self, client, auth_headers):
+        """The specific symptom: a path under /tmp that no longer exists."""
+        await client.post("/api/spaces", json={"name": "up2"}, headers=auth_headers)
+        await _upload(client, auth_headers, "report.md", "# Report\n\nBody text.", "up2")
+
+        for source in await _sources("up2"):
+            assert not source.startswith("/tmp/"), f"{source} is a server tempfile"
+            assert "tmp" not in source.lower(), f"{source} looks like a tempfile"
+
+    async def test_two_uploads_of_the_same_file_do_not_duplicate(self, client, auth_headers):
+        """
+        Migration 005 keys ingest identity on
+        (space_id, source_file, chunk_index, content_hash). A tempfile path is
+        different every request, so re-uploading the same file used to store a
+        second copy. A stable source name makes that identity work as intended.
+        """
+        await client.post("/api/spaces", json={"name": "up3"}, headers=auth_headers)
+        body = "# Stable\n\nIdentical on both uploads."
+
+        first = await _upload(client, auth_headers, "stable.md", body, "up3")
+        second = await _upload(client, auth_headers, "stable.md", body, "up3")
+        assert first.status_code == 200
+        assert second.status_code == 200
+
+        rows = await fetch_all(
+            """SELECT count(*) AS c FROM chunks c
+               JOIN memory_spaces ms ON ms.id = c.space_id
+               WHERE ms.name = %s""",
+            ("up3",),
+        )
+        first_count = first.json()["chunks_created"]
+        assert rows[0]["c"] == first_count, "re-uploading an unchanged file should not add rows"
+
+    async def test_different_files_keep_their_own_sources(self, client, auth_headers):
+        await client.post("/api/spaces", json={"name": "up4"}, headers=auth_headers)
+        await _upload(client, auth_headers, "alpha.md", "# Alpha\n\nOne.", "up4")
+        await _upload(client, auth_headers, "beta.md", "# Beta\n\nTwo.", "up4")
+
+        assert await _sources("up4") == ["alpha.md", "beta.md"]
+
+
+class TestOtherIngestPathsAreUnchanged:
+    """
+    Only uploads have a tempfile problem. CLI and directory ingestion read a
+    real path the user chose, and that path is the durable identifier — the
+    override must not disturb them.
+    """
+
+    async def test_pipeline_without_source_name_uses_the_file_path(self, tmp_path):
+        from memory_vault.services.ingestion import IngestionJob
+
+        job = IngestionJob(priority=1, file_path="/data/notes.md", space_id=1)
+        assert job.source_name is None, "default must leave the file path in charge"
+
+    async def test_text_ingest_still_records_its_own_source(self, client, auth_headers):
+        """`POST /api/ingest/text` has no file at all and must be untouched."""
+        await client.post("/api/spaces", json={"name": "up5"}, headers=auth_headers)
+        resp = await client.post(
+            "/api/ingest/text",
+            json={"text": "A memory with no file behind it.", "space": "up5"},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+
+        for source in await _sources("up5"):
+            assert not source.startswith("/tmp/")


### PR DESCRIPTION
File uploads stream to a `NamedTemporaryFile` and passed that path to the ingestion pipeline, so every chunk from an upload stored a `source_file` like `/tmp/tmpabcd1234.md` — a path that is deleted the moment the request ends.

Reproduced before fixing:

```
stored source_file: /tmp/tmpy20ug5a1.md
tempfile still exists: False
```

## The fix

The route already validated and kept `file.filename`. It simply never reached the adapter.

`IngestionJob` now carries an optional `source_name` that overrides what gets recorded. Detection still reads the real path, because it needs the extension of the file actually on disk — only the recorded source changes.

## It also repairs re-upload dedup

This is the part worth knowing about. Migration 005 keys ingest identity on `(space_id, source_file, chunk_index, content_hash)`. A tempfile path differs on every request, so that identity could never match and uploading the same file twice stored a second copy.

With a stable source name the identity works as intended. The RED run confirms it: `re-uploading an unchanged file should not add rows` failed before the fix and passes after.

## Upgrade note

Existing rows keep their tempfile paths — nothing is rewritten. A file uploaded before this change and again after it will not dedup against its older copy, because the two have different identities. Re-uploading after upgrading is idempotent from that point on.

## Other ingest paths are unchanged

CLI and directory ingestion pass no `source_name`. The path the user chose is the durable identifier there, and two tests pin that: `IngestionJob` defaults `source_name` to `None`, and `POST /api/ingest/text` — which has no file at all — is untouched.

## Testing

Verified RED against `main`: 5 failed, 1 passed. The failures name the bug directly — `assert ['/tmp/tmp_na4xp34.md']`, `is a server tempfile`, `should not add rows`. The single pass is the text-ingest path, which never had the problem and must not change.

Confirmed by mutation: ignoring the override fails 4 tests while both unchanged-path guards keep passing.

Full suite 463 passed, `ruff check` and `ruff format --check` clean.

Reported by @lcj-codex-coder.

Closes #101
