### PR TITLE
fix(graph): every entity occurrence gets its own mention

### DIFF
--- a/src/memory_vault/extraction/spacy_extractor.py
+++ b/src/memory_vault/extraction/spacy_extractor.py
@@ -72,10 +72,15 @@ except ImportError:
 
 
 def extract_entities(text: str) -> list[Entity]:
-    """Extract entities from a chunk of text.
+    """Extract entities from a chunk of text, one Entity per occurrence.
 
-    Returns a deduplicated list (by case-insensitive name + type) in
-    first-occurrence order. Types: Person, Project, Tool, Concept.
+    Entity *identity* is still case-insensitive name + type — the graph writer
+    upserts on that, so repeated mentions resolve to one node. What is no
+    longer collapsed is the occurrences: each hit keeps its own offsets, so
+    `entity_mentions` records where in the chunk the entity actually appears
+    rather than only where it first appeared.
+
+    Returned in first-occurrence order. Types: Person, Project, Tool, Concept.
     """
     if not _SPACY_READY or not text:
         return []
@@ -98,8 +103,10 @@ def extract_entities(text: str) -> list[Entity]:
             continue
         key = (name.lower(), mapped_type)
         ner_spans.append((ent.start_char, ent.end_char))
-        if key in seen:
-            continue
+        # `seen` still tracks identity so Concept extraction below does not
+        # re-add something already found as a Person or Tool. It no longer
+        # skips the entity itself: every occurrence gets its own offsets, and
+        # the writer upserts them onto one node.
         seen.add(key)
         entities.append(Entity(name=name, type=mapped_type, start=ent.start_char, end=ent.end_char))
 
@@ -117,20 +124,22 @@ def extract_entities(text: str) -> list[Entity]:
             concept_chunks.append((name, np.start_char, np.end_char))
 
     counts = Counter(name.lower() for name, _, _ in concept_chunks)
-    first_seen: dict[str, tuple[str, int, int]] = {}
+
+    # The occurrence threshold decides whether a noun chunk is a Concept at
+    # all; it is a property of the phrase, not of any one hit. So the count
+    # gates admission, and then every occurrence of an admitted phrase is
+    # emitted with its own offsets.
+    ner_names = {name for name, _type in seen}
+
     for name, start, end in concept_chunks:
         key = name.lower()
-        if key not in first_seen:
-            first_seen[key] = (name, start, end)
-
-    for key, count in counts.items():
-        if count < _MIN_CONCEPT_OCCURRENCES:
+        if counts[key] < _MIN_CONCEPT_OCCURRENCES:
             continue
-        concept_key = (key, "Concept")
-        if concept_key in seen:
+        if key in ner_names:
+            # Already recorded under a real type by the NER pass. Adding a
+            # Concept node for the same phrase would split one thing into two
+            # graph nodes.
             continue
-        seen.add(concept_key)
-        name, start, end = first_seen[key]
         entities.append(Entity(name=name, type="Concept", start=start, end=end))
 
     return entities

--- a/tests/test_entity_occurrences.py
+++ b/tests/test_entity_occurrences.py
@@ -1,0 +1,126 @@
+"""
+Every entity occurrence gets its own graph mention.
+
+`extract_entities` deduplicated by case-insensitive name and type and kept only
+the first hit, so the writer never saw later offsets. The schema comment for
+`entity_mentions` says "one row per (entity, chunk, location)" and the writer
+inserts per occurrence — the extractor upstream was defeating both.
+
+Identity dedup still applies: repeated mentions resolve to one entity node,
+because the writer upserts on (lower(name), type, space_id). What changed is
+that the occurrences beneath that node are no longer collapsed.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from memory_vault.extraction.spacy_extractor import extract_entities
+from memory_vault.models.db import fetch_all, fetch_one
+
+pytestmark = pytest.mark.asyncio
+
+
+class TestExtractorKeepsOccurrences:
+    async def test_repeated_person_yields_one_mention_each(self):
+        """The reported example."""
+        entities = extract_entities("Alice met Alice in Boston.")
+        alice = [e for e in entities if e.name.lower() == "alice"]
+
+        assert len(alice) == 2, f"expected two Alice occurrences, got {len(alice)}"
+        assert alice[0].start != alice[1].start, "each occurrence needs its own offsets"
+
+    async def test_offsets_point_at_the_real_positions(self):
+        text = "Alice met Alice in Boston."
+        alice = [e for e in extract_entities(text) if e.name.lower() == "alice"]
+
+        for e in alice:
+            assert text[e.start : e.end].lower() == "alice", (
+                f"offsets {e.start}:{e.end} do not span the entity"
+            )
+
+    async def test_identity_is_still_deduplicated(self):
+        """
+        Occurrences multiply; nodes must not. Two Alices are one entity in two
+        places, not two entities.
+        """
+        entities = extract_entities("Alice met Alice in Boston.")
+        identities = {(e.name.lower(), e.type) for e in entities}
+        alice_ids = {i for i in identities if i[0] == "alice"}
+
+        assert len(alice_ids) == 1, f"Alice should be one identity, got {alice_ids}"
+
+    async def test_distinct_entities_are_still_distinct(self):
+        entities = extract_entities("Alice met Bob in Boston.")
+        names = {e.name.lower() for e in entities}
+
+        assert "alice" in names and "bob" in names
+
+    async def test_single_occurrence_is_unchanged(self):
+        """Text without repetition must extract exactly as before."""
+        entities = extract_entities("Alice met Bob in Boston.")
+        alice = [e for e in entities if e.name.lower() == "alice"]
+
+        assert len(alice) == 1
+
+
+class TestMentionsReachTheDatabase:
+    """
+    The extractor change is only useful if the extra occurrences survive the
+    write path. These go through real ingestion rather than calling the writer
+    directly, so a regression anywhere between the two shows up here.
+    """
+
+    async def test_repeated_entity_stores_multiple_mentions(self, client, auth_headers):
+        await client.post("/api/spaces", json={"name": "occ1"}, headers=auth_headers)
+        resp = await client.post(
+            "/api/ingest/text",
+            json={"text": "Alice met Alice in Boston.", "space": "occ1"},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+
+        row = await fetch_one(
+            """SELECT count(*) AS mentions
+               FROM entity_mentions em
+               JOIN entities e ON e.id = em.entity_id
+               JOIN memory_spaces ms ON ms.id = e.space_id
+               WHERE ms.name = %s AND lower(e.name) = 'alice'""",
+            ("occ1",),
+        )
+        assert row["mentions"] >= 2, f"expected at least two stored mentions, got {row['mentions']}"
+
+    async def test_repeated_entity_is_still_one_node(self, client, auth_headers):
+        await client.post("/api/spaces", json={"name": "occ2"}, headers=auth_headers)
+        await client.post(
+            "/api/ingest/text",
+            json={"text": "Alice met Alice in Boston.", "space": "occ2"},
+            headers=auth_headers,
+        )
+
+        rows = await fetch_all(
+            """SELECT e.id FROM entities e
+               JOIN memory_spaces ms ON ms.id = e.space_id
+               WHERE ms.name = %s AND lower(e.name) = 'alice'""",
+            ("occ2",),
+        )
+        assert len(rows) == 1, f"Alice should be one node, found {len(rows)}"
+
+    async def test_mention_offsets_are_distinct_in_the_database(self, client, auth_headers):
+        await client.post("/api/spaces", json={"name": "occ3"}, headers=auth_headers)
+        await client.post(
+            "/api/ingest/text",
+            json={"text": "Alice met Alice in Boston.", "space": "occ3"},
+            headers=auth_headers,
+        )
+
+        rows = await fetch_all(
+            """SELECT em.start_offset, em.end_offset
+               FROM entity_mentions em
+               JOIN entities e ON e.id = em.entity_id
+               JOIN memory_spaces ms ON ms.id = e.space_id
+               WHERE ms.name = %s AND lower(e.name) = 'alice'""",
+            ("occ3",),
+        )
+        offsets = {(r["start_offset"], r["end_offset"]) for r in rows}
+        assert len(offsets) == len(rows), "each mention should have its own offsets"

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -46,12 +46,21 @@ def test_ner_label_mapping_unknown_labels_dropped():
     assert types.issubset({"Person", "Project", "Tool", "Concept"})
 
 
-def test_deduplication_within_chunk_keeps_one_entity():
+def test_deduplication_within_chunk_keeps_one_identity():
     text = "Claude helped me. Claude is great. I talked to Claude again."
     entities = extract_entities(text)
     claude_entities = [e for e in entities if e.name.lower() == "claude"]
-    # Case-insensitive dedup: only one Claude, regardless of type variant.
-    assert len(claude_entities) == 1
+
+    # Every occurrence is kept, each with its own offsets, so the graph can
+    # record where the entity actually appears rather than only where it first
+    # appeared. What dedup still guarantees is identity: repeated mentions
+    # resolve to one node, because the writer upserts on
+    # (lower(name), type, space_id).
+    assert len(claude_entities) > 1, "each occurrence should be extracted"
+    identities = {(e.name.lower(), e.type) for e in claude_entities}
+    assert len(identities) == 1, f"Claude should be one identity, got {identities}"
+    starts = {e.start for e in claude_entities}
+    assert len(starts) == len(claude_entities), "occurrences need distinct offsets"
 
 
 def test_concept_requires_min_occurrences():
@@ -83,9 +92,13 @@ def test_concept_first_seen_casing_preserved():
     )
     entities = extract_entities(text)
     concepts = [e for e in entities if e.type == "Concept" and e.name.lower() == "hybrid search"]
-    assert len(concepts) == 1
-    # First-seen lowercase casing is preserved (source text is already lowercase).
-    assert concepts[0].name == "hybrid search"
+
+    # Both occurrences are now recorded — the phrase qualifying as a Concept is
+    # a property of the phrase, so the occurrence count gates admission and
+    # then every hit is emitted with its own offsets.
+    assert len(concepts) > 1, "each occurrence of an admitted Concept should be kept"
+    # Casing comes from the source text at each position, which is lowercase here.
+    assert all(c.name == "hybrid search" for c in concepts)
 
 
 def test_concept_excludes_spans_overlapping_ner():


### PR DESCRIPTION
`extract_entities` deduplicated by case-insensitive name and type and kept only the first hit, so the graph writer never received later offsets.

Reproduced with the reported example:

```
'Alice met Alice in Boston.'
    Person   Alice        [0:5]
```

One mention. The second occurrence at `[10:15]` was lost before the writer saw it.

## Where the fix belongs

Not in `graph_writer.py`. That code inserts one row per occurrence with distinct offsets and is correct — as is the schema, whose comment reads *"one row per (entity, chunk, location)"*. The extractor upstream was defeating both, so a fix in the writer would have changed nothing.

## What changed, and what did not

**Unchanged:** entity identity. Repeated mentions still resolve to one node, because the writer upserts on `(lower(name), type, space_id)`.

**Changed:** the occurrences beneath that node are no longer collapsed.

```
'Alice met Alice in Boston.'  mentions=2 distinct_nodes=1
    Person   Alice        [0:5]
    Person   Alice        [10:15]
```

The Concept path needed the same treatment for a slightly different reason. The occurrence threshold decides whether a noun phrase is a Concept *at all* — that is a property of the phrase, not of any single hit — so the count still gates admission, and then every occurrence of an admitted phrase is emitted with its own offsets.

## This is a behaviour change

Worth stating plainly rather than burying: `entity_mentions` grows faster on entity-dense text, and mention counts on the graph page will rise for existing users when content is re-ingested. Existing rows are not rewritten.

## On the two existing tests

`test_deduplication_within_chunk_keeps_one_entity` and `test_concept_first_seen_casing_preserved` encoded the old contract and now assert the new one.

They were not wrong about identity dedup — that still holds, and the updated tests check it explicitly by comparing `(name, type)` identities rather than by counting extracted entries. Counting entries was the thing that changed.

## Testing

Verified RED against `main`: 2 failed, 6 passed. Both failures quantify the bug (`expected two Alice occurrences, got 1`, `expected at least two stored mentions, got 1`) — one at the extractor, one after a real ingest, so a regression anywhere between the two shows up. The 6 passes are the invariants that must hold on both sides of the change: identity stays deduplicated, distinct entities stay distinct, offsets point at real positions, single occurrences are unaffected.

Confirmed by mutation: restoring the old dedup fails 3 tests, including the updated existing one, while all 18 invariant tests keep passing.

Full suite 471 passed, `ruff check` and `ruff format --check` clean.

Reported by @lcj-codex-coder.

Closes #110
