### PR TITLE
fix(web): stop re-uploading finished files and stranding stopped answers

### DIFF
--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -153,7 +153,20 @@ export default function ChatPage() {
       })
     } catch (err) {
       if (controller.signal.aborted) {
-        // user-initiated cancel — leave state as-is
+        // User-initiated cancel. The outer `streaming` flag is cleared in
+        // `finally`, but rendering keys off the turn's own status — so leaving
+        // it as 'streaming' left a stopped answer showing "Thinking…" or a
+        // pulsing cursor indefinitely. Move it to a terminal state while
+        // keeping whatever text had already arrived.
+        setTurns((prev) => {
+          const next = [...prev]
+          const idx = next.length - 1
+          const cur = next[idx]
+          if (cur.role === 'assistant' && cur.status === 'streaming') {
+            next[idx] = { ...cur, status: 'done' }
+          }
+          return next
+        })
       } else {
         const message =
           err instanceof ApiError

--- a/web/src/pages/Ingest.tsx
+++ b/web/src/pages/Ingest.tsx
@@ -251,7 +251,16 @@ function FileTab() {
     if (files.length === 0 || running) return
     setRunning(true)
 
-    for (let i = 0; i < files.length; i++) {
+    // Only the entries still pending. This loop used to run over every file
+    // and reset each status to 'uploading' regardless of what it already was,
+    // so adding a file after a finished batch re-uploaded the completed ones —
+    // while the button correctly offered to ingest only the new file. The
+    // filter matches `pendingCount`, so what runs is what the button promised.
+    const pendingIndexes = statuses
+      .map((s, i) => (s.state === 'pending' ? i : -1))
+      .filter((i) => i !== -1)
+
+    for (const i of pendingIndexes) {
       setStatuses((prev) => {
         const next = [...prev]
         next[i] = { state: 'uploading' }


### PR DESCRIPTION
Two dashboard state bugs, both reported with precise locations.

## Adding a file after a batch re-uploaded the finished ones (#106)

The submit loop ran over every file and reset each status to `uploading` without checking what it already was:

```tsx
for (let i = 0; i < files.length; i++) {
  setStatuses(...)  // unconditionally 'uploading'
```

So a file already marked `done` was ingested a second time — while the button correctly said **Ingest 1 file**, because `pendingCount` filters on `state === 'pending'`. The button and the loop disagreed about what "submit" meant.

The loop now iterates only the pending entries, using the same filter the button counts. What runs is what the button promised.

## Stopping a chat left the answer marked streaming (#107)

The abort branch deliberately left the turn untouched:

```tsx
if (controller.signal.aborted) {
  // user-initiated cancel — leave state as-is
}
```

`finally` clears the outer `streaming` flag, so the input unlocks and the request is visibly over. But rendering keys off the *turn's* status, so the stopped answer kept showing "Thinking…" or a pulsing cursor indefinitely.

The turn now moves to a terminal state on abort, keeping whatever text had already arrived — stopping should end the response, not discard it.

## Verification

These are React state changes with no Python coverage, so the checks that matter are the frontend ones. Installed the web dependencies and ran the real toolchain rather than relying on the editor:

- `tsc -b` — passes
- `eslint .` — clean
- `npm run build` — production bundle builds

The Python suite is unaffected: 471 passed, `ruff check` and `ruff format --check` clean.

Reported by @lcj-codex-coder.

Closes #106, closes #107
