### PR TITLE
feat(memory): purge memories that were forgotten long ago

### DIFF
--- a/src/memory_vault/cli.py
+++ b/src/memory_vault/cli.py
@@ -47,6 +47,19 @@ def main() -> None:
     # migrate
     sub.add_parser("migrate", help="Run database migrations")
 
+    # purge-forgotten
+    p_purge = sub.add_parser(
+        "purge-forgotten",
+        help="Permanently delete memories forgotten more than N days ago",
+    )
+    p_purge.add_argument(
+        "--older-than",
+        type=int,
+        default=30,
+        metavar="DAYS",
+        help="Only purge memories forgotten at least this many days ago (default: 30)",
+    )
+
     # mcp
     sub.add_parser("mcp", help="Start the MCP server (stdio transport)")
 
@@ -101,6 +114,8 @@ def main() -> None:
 
     if args.command == "migrate":
         asyncio.run(_cmd_migrate())
+    elif args.command == "purge-forgotten":
+        asyncio.run(_cmd_purge_forgotten(args.older_than))
     elif args.command == "ingest":
         asyncio.run(_cmd_ingest(args.file, args.space))
     elif args.command == "search":
@@ -131,6 +146,38 @@ def main() -> None:
         from memory_vault.diagnose import cli_diagnose
 
         cli_diagnose(Path(args.out_dir) if args.out_dir else None)
+
+
+async def _cmd_purge_forgotten(older_than_days: int) -> None:
+    """Permanently delete memories forgotten more than `older_than_days` ago.
+
+    Exposed on the CLI as well as over MCP so an operator can schedule it —
+    their cron, their retention policy, their machine. Memory Vault runs no
+    timer of its own; deleting someone's notes should be something they asked
+    for, not something that happens while they are not looking.
+    """
+    import json
+
+    from memory_vault.mcp.server import purge_forgotten
+    from memory_vault.models.db import close_pool, init_pool
+
+    if older_than_days < 0:
+        print("--older-than cannot be negative.")
+        sys.exit(1)
+
+    await init_pool()
+    try:
+        result = json.loads(await purge_forgotten(older_than_days=older_than_days))
+        if not result.get("success"):
+            print(f"Purge failed: {result.get('error', 'unknown error')}")
+            sys.exit(1)
+        print(
+            f"Purged {result['purged']} memory(ies) forgotten more than "
+            f"{older_than_days} day(s) ago. {result['remaining']} forgotten "
+            f"memory(ies) remain."
+        )
+    finally:
+        await close_pool()
 
 
 async def _cmd_migrate() -> None:

--- a/src/memory_vault/mcp/server.py
+++ b/src/memory_vault/mcp/server.py
@@ -524,6 +524,68 @@ async def forget(chunk_id: str) -> str:
         return _dumps({"success": False, "error": str(e)})
 
 
+# ---------------------------------------------------------------------------
+# Tool: purge_forgotten
+# ---------------------------------------------------------------------------
+
+DEFAULT_PURGE_AGE_DAYS = 30
+
+
+@mcp.tool()
+async def purge_forgotten(older_than_days: int = DEFAULT_PURGE_AGE_DAYS) -> str:
+    """
+    Permanently delete memories that were forgotten a while ago.
+
+    `forget` is a soft delete: the memory stops appearing in search but the row
+    stays, so it can be recovered. Nothing removed it afterwards, so a vault
+    that is edited often accumulated one dead row per edit forever.
+
+    This is the deliberate, irreversible half. It is never automatic — there is
+    no timer that quietly deletes your memories — and it only touches memories
+    already marked forgotten, never active ones.
+
+    Args:
+        older_than_days: Only purge memories forgotten at least this many days
+            ago. The default keeps a month of recovery, so purging right after
+            an accidental forget still spares it. Pass 0 to purge every
+            forgotten memory regardless of age.
+    """
+    if not await _ensure_db():
+        return _dumps({"success": False, "error": "Database offline"})
+
+    if older_than_days < 0:
+        return _dumps({"success": False, "error": "older_than_days cannot be negative."})
+
+    try:
+        # Graph rows clean themselves up: entity_mentions.chunk_id and
+        # relationships.chunk_id are both ON DELETE CASCADE.
+        purged = await execute_query(
+            """DELETE FROM chunks
+               WHERE (metadata->>'forgotten')::boolean IS TRUE
+                 AND (metadata->>'forgotten_at')::timestamptz
+                     <= now() - make_interval(days => %s)""",
+            (older_than_days,),
+        )
+
+        remaining = await fetch_one(
+            """SELECT COUNT(*) AS n FROM chunks
+               WHERE (metadata->>'forgotten')::boolean IS TRUE"""
+        )
+
+        return _dumps(
+            {
+                "success": True,
+                "purged": purged,
+                "remaining": int(remaining["n"]) if remaining else 0,
+                "older_than_days": older_than_days,
+            }
+        )
+
+    except Exception as e:
+        logger.exception("purge_forgotten failed")
+        return _dumps({"success": False, "error": str(e)})
+
+
 @mcp.tool()
 async def move_memory(chunk_id: str, target_space: str) -> str:
     """
@@ -632,6 +694,11 @@ async def memory_status() -> str:
                 "embedding_model": MODEL_NAME,
                 "total_chunks": total_chunks,
                 "active_chunks": active_chunks,
+                # The difference was already derivable, but only by subtracting.
+                # Naming it makes accumulation something an operator can see
+                # rather than compute — and it is what tells them whether
+                # purge_forgotten is worth running.
+                "forgotten_chunks": total_chunks - active_chunks,
                 "chunks_per_space": spaces,
                 "queries_24h": ql["cnt"] if ql else 0,
                 "avg_latency_ms": round(float(ql["avg_lat"]), 1) if ql and ql["avg_lat"] else None,

--- a/tests/test_purge_forgotten.py
+++ b/tests/test_purge_forgotten.py
@@ -1,0 +1,161 @@
+"""
+Purging forgotten memories.
+
+`forget` is a soft delete — the row stays so the memory can be recovered — and
+nothing ever removed it afterwards. A vault that is edited often accumulated one
+dead row per edit, forever, because editing a memory means forget + remember.
+
+`purge_forgotten` is the deliberate other half. It is never automatic: Memory
+Vault runs no timer, so deleting someone's notes is something they asked for
+rather than something that happened while they were not looking. The age filter
+is what keeps a purge run safe right after an accidental forget.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from memory_vault.mcp import server as mcp
+from memory_vault.models.db import execute_query, fetch_one
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _remember_and_get_id(text: str) -> str:
+    result = json.loads(await mcp.remember(text=text))
+    return result["chunk_id"]
+
+
+async def _backdate_forget(chunk_id: str, days: int) -> None:
+    """Move a chunk's forgotten_at into the past so age filters can be tested."""
+    await execute_query(
+        """UPDATE chunks
+           SET metadata = jsonb_set(
+               metadata, '{forgotten_at}',
+               to_jsonb((now() - make_interval(days => %s))::text))
+           WHERE id = %s""",
+        (days, chunk_id),
+    )
+
+
+async def _exists(chunk_id: str) -> bool:
+    row = await fetch_one("SELECT 1 AS x FROM chunks WHERE id = %s", (chunk_id,))
+    return row is not None
+
+
+class TestAgeFilter:
+    async def test_recent_forget_survives_the_default_window(self):
+        """
+        The undo window. Purging immediately after an accidental forget must
+        not destroy the thing that was just forgotten.
+        """
+        chunk_id = await _remember_and_get_id("A memory forgotten just now.")
+        await mcp.forget(chunk_id=chunk_id)
+
+        result = json.loads(await mcp.purge_forgotten())
+
+        assert result["success"] is True
+        assert await _exists(chunk_id), "a memory forgotten today must survive a 30-day purge"
+
+    async def test_old_forget_is_purged(self):
+        chunk_id = await _remember_and_get_id("A memory forgotten long ago.")
+        await mcp.forget(chunk_id=chunk_id)
+        await _backdate_forget(chunk_id, 60)
+
+        result = json.loads(await mcp.purge_forgotten())
+
+        assert result["purged"] >= 1
+        assert not await _exists(chunk_id), "a memory forgotten 60 days ago should be gone"
+
+    async def test_zero_days_purges_every_forgotten_memory(self):
+        chunk_id = await _remember_and_get_id("Forgotten and purged in the same breath.")
+        await mcp.forget(chunk_id=chunk_id)
+
+        result = json.loads(await mcp.purge_forgotten(older_than_days=0))
+
+        assert result["remaining"] == 0
+        assert not await _exists(chunk_id)
+
+    async def test_negative_days_is_rejected(self):
+        result = json.loads(await mcp.purge_forgotten(older_than_days=-1))
+        assert result["success"] is False
+        assert "negative" in result["error"].lower()
+
+
+class TestActiveMemoriesAreNeverTouched:
+    """The property that makes this safe to run at all."""
+
+    async def test_active_memory_survives_a_full_purge(self):
+        keep = await _remember_and_get_id("An active memory that must not be purged.")
+        drop = await _remember_and_get_id("A forgotten memory that should go.")
+        await mcp.forget(chunk_id=drop)
+
+        await mcp.purge_forgotten(older_than_days=0)
+
+        assert await _exists(keep), "purge must never delete an active memory"
+        assert not await _exists(drop)
+
+    async def test_purge_with_nothing_forgotten_is_a_no_op(self):
+        keep = await _remember_and_get_id("Nothing here has been forgotten.")
+
+        result = json.loads(await mcp.purge_forgotten(older_than_days=0))
+
+        assert result["success"] is True
+        assert await _exists(keep)
+
+
+class TestGraphRowsGoWithTheChunk:
+    async def test_entity_mentions_are_removed_by_cascade(self):
+        """
+        entity_mentions.chunk_id is ON DELETE CASCADE, so purging a chunk takes
+        its graph rows with it. Asserting it here means a schema change that
+        drops the cascade cannot pass unnoticed and leave orphans behind.
+        """
+        chunk_id = await _remember_and_get_id("Alice and Bob discussed Postgres in Boston.")
+
+        before = await fetch_one(
+            "SELECT COUNT(*) AS n FROM entity_mentions WHERE chunk_id = %s", (chunk_id,)
+        )
+        if before["n"] == 0:
+            pytest.skip("extraction produced no mentions for this text")
+
+        await mcp.forget(chunk_id=chunk_id)
+        await mcp.purge_forgotten(older_than_days=0)
+
+        after = await fetch_one(
+            "SELECT COUNT(*) AS n FROM entity_mentions WHERE chunk_id = %s", (chunk_id,)
+        )
+        assert after["n"] == 0, "graph mentions should not outlive their chunk"
+
+
+class TestReporting:
+    async def test_remaining_counts_what_is_left(self):
+        old = await _remember_and_get_id("Old forgotten memory for the count.")
+        recent = await _remember_and_get_id("Recent forgotten memory for the count.")
+        await mcp.forget(chunk_id=old)
+        await mcp.forget(chunk_id=recent)
+        await _backdate_forget(old, 60)
+
+        result = json.loads(await mcp.purge_forgotten(older_than_days=30))
+
+        assert result["purged"] == 1, "only the old one should go"
+        assert result["remaining"] == 1, "the recent one should still be counted"
+
+    async def test_status_names_the_forgotten_count(self):
+        """
+        The number was derivable as total - active, but only by subtracting.
+        Naming it is what tells an operator whether purging is worth doing.
+        """
+        chunk_id = await _remember_and_get_id("A memory that will show in the count.")
+        before = json.loads(await mcp.memory_status())
+        await mcp.forget(chunk_id=chunk_id)
+        after = json.loads(await mcp.memory_status())
+
+        assert "forgotten_chunks" in after
+        assert after["forgotten_chunks"] == before["forgotten_chunks"] + 1
+        assert after["active_chunks"] == before["active_chunks"] - 1
+        assert after["total_chunks"] == before["total_chunks"], (
+            "a soft delete should not change the total until it is purged"
+        )


### PR DESCRIPTION
`forget` is a soft delete — the row stays so the memory can be recovered — and nothing ever removed it afterwards. Editing a memory means forget plus remember, so a vault that is edited often accumulated one dead row per edit, indefinitely.

On the default Docker setup that is invisible, because the database gets rebuilt. On a long-lived deployment against a dedicated Postgres it is unbounded growth, which is where this was reported from.

## What ships

**`purge_forgotten(older_than_days=30)`** over MCP, and **`memory-vault purge-forgotten [--older-than DAYS]`** on the CLI. It only touches memories already marked forgotten; active memories are never eligible.

**`memory_status` gains `forgotten_chunks`.** The number was already derivable by subtracting `active_chunks` from `total_chunks`, but naming it is what tells an operator whether purging is worth doing.

## Why it is not automatic

That is a decision, not an omission, and worth stating plainly since the issue offered both shapes.

Memory Vault runs no scheduler — the only background task in the codebase is the per-request ingestion worker pool. A timer would have to live in one of the two server processes, and the deployment that needs compaction most is stdio MCP against a remote database, which has no long-running process at all. An in-process sweep would silently not run for the people who asked for this.

Deleting someone's notes should also be something they asked for rather than something that happens while they are not looking. `forget` currently promises recoverability; a timed sweep would quietly convert that promise into a deadline discovered only when recovery fails.

Operators who want it scheduled can cron the CLI command — their scheduler, their retention policy, their machine, and it reaches stdio deployments that an internal timer never would.

## The age filter is the undo window

The default removes only what was forgotten at least a month ago, so purging right after an accidental `forget` still spares it. Pass `0` to purge everything forgotten.

Verified end to end before writing any assertions:

```
before purge: total=3 active=1 forgotten=2
purge(default 30d): purged=1 remaining=1   ← only the backdated one
after:  total=2 active=1 forgotten=1
purge(0d): purged=1 remaining=0
final:  total=1 active=1 forgotten=0       ← the active memory never moved
```

## Graph rows

No explicit cleanup is needed: `entity_mentions.chunk_id` and `relationships.chunk_id` are both `ON DELETE CASCADE`. A test asserts it anyway, so a future schema change that drops the cascade cannot quietly start leaving orphans behind.

## Testing

9 tests: the recent forget survives the default window, an old one is purged, `older_than_days=0` clears everything, negatives are rejected, active memories survive a full purge, purging with nothing forgotten is a no-op, cascade removes graph rows, `remaining` reports what is left, and the new status field tracks correctly.

Confirmed by mutation: removing the age filter fails exactly the two tests guarding the undo window, while the safety properties keep passing.

Full suite 480 passed, `ruff check` and `ruff format --check` clean.

Reported by @git-pharos.

Closes #74
