### PR TITLE
chore: bump version to 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,82 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.0] — 2026-08-23
+
+Ten bug fixes and one new capability. Most of these are the kind that only
+surface once you have been using Memory Vault for a while: a budget that was
+not really a cap, a chunk limit that was not really a limit, forgotten memories
+that never actually went away.
+
+Nothing here requires action on upgrade.
+
+### Added
+
+- **Forgotten memories can be purged.** `forget` is a soft delete so a memory
+  can be recovered, but nothing ever removed the rows afterwards — and editing a
+  memory means forget plus remember, so a vault that is edited often grew a dead
+  row per edit. `purge_forgotten(older_than_days=30)` over MCP, or
+  `memory-vault purge-forgotten` on the command line, deletes them for good.
+  It is deliberately not automatic: Memory Vault runs no timer, so nothing
+  deletes your memories unless you ask. The default only removes what was
+  forgotten at least a month ago, so purging right after an accidental forget
+  still spares it. ([#74])
+- **`memory_status` reports `forgotten_chunks`.** The number was derivable by
+  subtracting, but naming it is what tells you whether purging is worth doing.
+  ([#74])
+
+### Fixed
+
+- **A single oversized result could blow the token budget.** Both the chat and
+  MCP budget helpers admitted one arbitrarily large result — 2540 tokens against
+  a 200 budget in the reported case, and the caller was not even told it had
+  happened. Keeping at least one result is deliberate, since an answer with no
+  context is worse than one with trimmed context; sending it whole was not. The
+  final result is now trimmed to what is left. ([#99])
+- **`max_words` was not an upper bound.** A sentence longer than the limit had
+  no sentence boundary to split on, so it passed through whole — and because the
+  flush was guarded on the accumulator being non-empty, an oversized *first*
+  sentence escaped even with more text after it. Word splitting is now the
+  floor under everything else. ([#103])
+- **Uploaded files recorded the server's temporary path as their source.** Every
+  chunk from an upload pointed at something like `/tmp/tmpabcd1234.md`, deleted
+  the moment the request ended. Uploads now record the filename you sent — which
+  also repairs re-upload deduplication, since a path that changes every request
+  could never match. ([#101])
+- **Repeated entity occurrences collapsed to one graph mention.** "Alice met
+  Alice" recorded one mention rather than two. Entity identity is still
+  deduplicated — repeated mentions resolve to one node — but each occurrence now
+  keeps its own offsets. Expect mention counts to rise as content is
+  re-ingested. ([#110])
+- **An empty environment variable crashed at start-up.** `os.getenv` falls back
+  to its default only when a key is absent, so `DB_PORT=""` reached `int()` and
+  raised. Config generated from a manifest emits every declared key, empty where
+  it has no value, which made this a first-run failure. Empty now means unset,
+  and a malformed value names the setting instead of failing from inside the
+  standard library. ([#181])
+- **Concurrent creation of the same space returned 500.** Two callers could both
+  see no existing row and both insert; the loser hit the unique constraint. The
+  insert is now authoritative and the loser gets the same 409 as any other
+  duplicate. ([#112])
+- **A malformed UUID in a path returned 500.** `not-a-valid-identifier` reached
+  PostgreSQL and became a server error. Those routes now reject it at the
+  boundary without opening a database connection. ([#102])
+- **Adding a file after a finished batch re-uploaded the completed ones.** The
+  submit loop ran over every file regardless of status, so a file already
+  ingested went again — while the button correctly offered to ingest only the
+  new one. ([#106])
+- **Stopping a chat left the answer marked as streaming.** The input unlocked
+  and the request ended, but the turn kept showing "Thinking…" indefinitely. It
+  now reaches a terminal state while keeping whatever text had arrived. ([#107])
+
+### Contributors
+
+- [@lcj-codex-coder] (Leonard Janke — lcjanke2020, working with GPT-5.6-Sol
+  through OpenAI Codex) — reported [#99], [#101], [#102], [#103], [#106],
+  [#107], [#110], [#112]
+- [@git-pharos] — reported [#74], the unbounded growth that `purge_forgotten`
+  answers
+
 ## [1.3.0] — 2026-08-23
 
 Least privilege. The containers no longer run as root, the database role that
@@ -524,7 +600,8 @@ assistants and the apps you build on top of them.
 - 163 tests passing in CI against a real Postgres + pgvector service
   container.
 
-[Unreleased]: https://github.com/MihaiBuilds/memory-vault/compare/v1.3.0...HEAD
+[Unreleased]: https://github.com/MihaiBuilds/memory-vault/compare/v1.4.0...HEAD
+[1.4.0]: https://github.com/MihaiBuilds/memory-vault/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/MihaiBuilds/memory-vault/compare/v1.2.1...v1.3.0
 [1.2.1]: https://github.com/MihaiBuilds/memory-vault/compare/v1.2.0...v1.2.1
 [1.2.0]: https://github.com/MihaiBuilds/memory-vault/compare/v1.1.1...v1.2.0
@@ -562,6 +639,15 @@ assistants and the apps you build on top of them.
 [#96]: https://github.com/MihaiBuilds/memory-vault/pull/96
 [#97]: https://github.com/MihaiBuilds/memory-vault/issues/97
 [#98]: https://github.com/MihaiBuilds/memory-vault/issues/98
+[#99]: https://github.com/MihaiBuilds/memory-vault/issues/99
+[#101]: https://github.com/MihaiBuilds/memory-vault/issues/101
+[#102]: https://github.com/MihaiBuilds/memory-vault/issues/102
+[#103]: https://github.com/MihaiBuilds/memory-vault/issues/103
+[#106]: https://github.com/MihaiBuilds/memory-vault/issues/106
+[#107]: https://github.com/MihaiBuilds/memory-vault/issues/107
+[#110]: https://github.com/MihaiBuilds/memory-vault/issues/110
+[#112]: https://github.com/MihaiBuilds/memory-vault/issues/112
+[#181]: https://github.com/MihaiBuilds/memory-vault/issues/181
 [#100]: https://github.com/MihaiBuilds/memory-vault/issues/100
 [#104]: https://github.com/MihaiBuilds/memory-vault/issues/104
 [#105]: https://github.com/MihaiBuilds/memory-vault/issues/105

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       retries: 10
 
   app:
-    image: ghcr.io/mihaibuilds/memory-vault:1.3.0
+    image: ghcr.io/mihaibuilds/memory-vault:1.4.0
     depends_on:
       db:
         condition: service_healthy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "memory-vault"
-version = "1.3.0"
+version = "1.4.0"
 description = "Local-first AI memory system with hybrid search — PostgreSQL + pgvector"
 readme = "README.md"
 license = "MIT"

--- a/server.json
+++ b/server.json
@@ -8,11 +8,11 @@
     "url": "https://github.com/MihaiBuilds/memory-vault",
     "source": "github"
   },
-  "version": "1.3.0",
+  "version": "1.4.0",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/mihaibuilds/memory-vault-mcp:1.3.0",
+      "identifier": "ghcr.io/mihaibuilds/memory-vault-mcp:1.4.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Version bump for the v1.4.0 release.

## What ships

**Nine bug fixes**, most of the kind that only surface after a while of real use:

- A token budget that was not really a cap — one oversized result could exceed it by 13× ([#99])
- A chunk limit that was not really a limit — a long sentence with no boundary passed through whole ([#103])
- Uploads recording a server tempfile as their source, which also broke re-upload deduplication ([#101])
- Repeated entity occurrences collapsing to a single graph mention ([#110])
- An empty environment variable crashing at start-up, before anything could report it ([#181])
- Concurrent space creation returning 500 instead of 409 ([#112])
- Malformed UUIDs in a path returning 500 ([#102])
- Adding a file after a finished batch re-uploading the completed ones ([#106])
- Stopping a chat leaving the answer marked as streaming forever ([#107])

**One new capability:** forgotten memories can be purged ([#74]). `forget` is a soft delete so a memory can be recovered, but nothing removed the rows afterwards — and editing a memory means forget plus remember, so an actively-edited vault grew a dead row per edit.

`purge_forgotten(older_than_days=30)` over MCP, or `memory-vault purge-forgotten` on the command line. Deliberately not automatic: Memory Vault runs no timer, so nothing deletes your memories unless you ask. The default only removes what was forgotten at least a month ago, so purging right after an accidental forget still spares it.

## Upgrading

Nothing to do. No migrations, no configuration changes, no behaviour that requires action.

Two changes are worth knowing about:

- **Mention counts will rise** as content is re-ingested, because each entity occurrence now records its own graph mention rather than only the first.
- **Re-upload deduplication starts working from this version.** Rows stored before it keep their old tempfile source, so a file uploaded both before and after the upgrade will not deduplicate against its older copy.

## This bump

Version raised in all four places: `pyproject.toml`, the `docker-compose.yml` image tag, and the `version` plus OCI identifier in `server.json`. Adds the `[1.4.0]` compare link and the nine issue references the changelog entry cites.

Full suite 480 passed, `ruff check` and `ruff format --check` clean.
