### PR TITLE
deps(python): raise ruff, uvicorn and python-dotenv floors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,13 +15,13 @@ dependencies = [
     "psycopg-pool>=3.3.1,<4",
     "sentence-transformers>=5.7.0,<6",
     "numpy>=2.4.6",
-    "python-dotenv>=1.2.2",
+    "python-dotenv>=1.2.3",
     # 2.x replaced mcp.server.fastmcp with mcp.server.mcpserver, so 1.x and 2.x
     # cannot both be supported by one import. The floor is 2.0.0 for that
     # reason rather than a feature need.
     "mcp>=2.0.0,<3.0.0",
     "fastapi>=0.141.1,<1",
-    "uvicorn[standard]>=0.52.3,<1",
+    "uvicorn[standard]>=0.52.4,<1",
     "python-multipart>=0.0.32",
     "pydantic>=2.13.4,<3",
     "spacy>=3.8.15,<4",
@@ -33,7 +33,7 @@ dev = [
     "pytest>=9.1.1",
     "pytest-asyncio>=1.4.0",
     "httpx>=0.28.1",
-    "ruff>=0.16.3",
+    "ruff>=0.16.4",
     # Used by the container-hardening tests to read docker-compose.yml. It
     # arrives transitively today; declaring it means a dependency bump cannot
     # silently take the test suite with it.


### PR DESCRIPTION
Combines three dependabot PRs into one change:

- #190 — ruff `>=0.16.3` → `>=0.16.4`
- #191 — uvicorn `>=0.52.3` → `>=0.52.4`
- #192 — python-dotenv `>=1.2.2` → `>=1.2.3`

All three are one-line floor bumps to the same file. Merged separately, each one puts the others behind and costs a rebase plus a full CI cycle, so they go together here.

Verified with a `--no-cache` rebuild of the test image so dependencies resolved fresh: ruff 0.16.5, uvicorn 0.52.4, python-dotenv 1.2.3. Full suite 480 passed, `ruff check` and `ruff format --check` clean.

Closes #190
Closes #191
Closes #192
