### PR TITLE
deps(python): raise mcp, ruff and spacy floors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,14 +17,15 @@ dependencies = [
     "numpy>=2.4.6",
     "python-dotenv>=1.2.3",
     # 2.x replaced mcp.server.fastmcp with mcp.server.mcpserver, so 1.x and 2.x
-    # cannot both be supported by one import. The floor is 2.0.0 for that
-    # reason rather than a feature need.
-    "mcp>=2.0.0,<3.0.0",
+    # cannot both be supported by one import — that is why the floor sits in
+    # the 2.x line at all. 2.1.1 specifically brings a request body limit to
+    # the SSE endpoints, which matters once the HTTP transport lands.
+    "mcp>=2.1.1,<3.0.0",
     "fastapi>=0.141.1,<1",
     "uvicorn[standard]>=0.52.4,<1",
     "python-multipart>=0.0.32",
     "pydantic>=2.13.4,<3",
-    "spacy>=3.8.15,<4",
+    "spacy>=3.8.16,<4",
     "structlog>=26.1.0,<27",
 ]
 
@@ -33,7 +34,7 @@ dev = [
     "pytest>=9.1.1",
     "pytest-asyncio>=1.4.0",
     "httpx>=0.28.1",
-    "ruff>=0.16.4",
+    "ruff>=0.16.5",
     # Used by the container-hardening tests to read docker-compose.yml. It
     # arrives transitively today; declaring it means a dependency bump cannot
     # silently take the test suite with it.


### PR DESCRIPTION
Combines three dependabot PRs into one change:

- #196 — mcp `>=2.0.0` → `>=2.1.1`
- #197 — ruff `>=0.16.4` → `>=0.16.5`
- #199 — spacy `>=3.8.15` → `>=3.8.16`

All three are floor bumps to the same file. Merged separately, each one puts the others behind and costs a rebase plus a full CI cycle.

## The mcp bump, in more detail

That one got a closer look than the other two, because the remote-transport work depends on that SDK and the shipped image resolves to exactly 2.0.0 today — so this is a real version change rather than a no-op floor raise.

Comparing the API surface Memory Vault actually uses, across both versions, turned up **exactly one difference, and it is additive**:

| surface | 2.0.0 → 2.1.1 |
| --- | --- |
| `MCPServer.run()` | identical |
| `token_verifier` in `__init__` | present in both |
| `streamable_http_app()` | identical |
| `TokenVerifier.verify_token()` | identical |
| `AccessToken` fields | identical |
| `@tool()` decorator | identical |
| `sse_app()` | **gains `max_request_body_size`** |

That addition comes from the upstream change applying a request body limit to the SSE and OAuth endpoints — hardening on the transport an HTTP surface would use, so it is worth having before that work rather than after.

## Verification

Fresh `--no-cache` rebuild so dependencies resolved cleanly: mcp 2.1.1, ruff 0.16.6, spacy 3.8.16.

The suite alone does not exercise the MCP protocol, so the mcp bump was also checked by building the MCP image on 2.1.1 and driving the real thing over stdio: `initialize` succeeded, all six tools listed, `remember` returned `stored: true`, and the write was confirmed present in Postgres afterwards.

Full suite 480 passed, `ruff check` and `ruff format --check` clean.

## Also

The comment above the mcp pin said the floor was 2.0.0 and existed for import reasons rather than a feature need. Both halves were stale, so it now says what is actually true.

Closes #196
Closes #197
Closes #199
