### PR TITLE
feat(search): ef_search as a per-query knob

### DIFF
--- a/src/memory_vault/api/routers/search.py
+++ b/src/memory_vault/api/routers/search.py
@@ -38,6 +38,7 @@ async def search(req: SearchRequest) -> SearchResponse:
         space_ids=space_ids,
         since=since_dt,
         limit=req.limit,
+        ef_search=req.ef_search,
     )
 
     await log_query(req.query, space_ids or None, results, elapsed_ms)

--- a/src/memory_vault/api/schemas.py
+++ b/src/memory_vault/api/schemas.py
@@ -37,6 +37,12 @@ class SearchRequest(BaseModel):
     spaces: list[str] | None = Field(default=None, examples=[["default"]])
     since: str | None = Field(default=None, examples=["2026-01-01"])
     limit: int = Field(default=10, ge=1, le=50)
+    # HNSW search breadth for this query only. Omit to use the server default
+    # (40). Higher values search more of the index — better recall, slower
+    # query — which is worth reaching for on a large or noisy corpus. Bounded
+    # here as well as in the service so an out-of-range value is a 422 rather
+    # than a silent clamp.
+    ef_search: int | None = Field(default=None, ge=1, le=1000, examples=[100])
 
 
 class SearchHit(BaseModel):

--- a/src/memory_vault/mcp/server.py
+++ b/src/memory_vault/mcp/server.py
@@ -193,6 +193,7 @@ async def recall(
     since: str | None = None,
     limit: int = 10,
     max_tokens: int = 2000,
+    ef_search: int | None = None,
 ) -> str:
     """
     Search your memories for information relevant to a query.
@@ -208,6 +209,10 @@ async def recall(
         since: Only return memories after this date (ISO format, e.g. "2025-01-01").
         limit: Maximum number of results (default 10, max 50).
         max_tokens: Token budget for results (default 2000).
+        ef_search: How much of the vector index to search, 1-1000. Omit to use
+                the default (40). Raise it when a search should have found
+                something and did not — better recall, slower query. Worth
+                trying before concluding a memory is missing.
     """
     if not await _ensure_db():
         return _dumps(
@@ -238,6 +243,7 @@ async def recall(
             space_ids=space_ids,
             since=since_dt,
             limit=limit,
+            ef_search=ef_search,
         )
 
         # Observability: memory_status reads queries_24h from query_log,

--- a/src/memory_vault/models/db.py
+++ b/src/memory_vault/models/db.py
@@ -188,6 +188,35 @@ async def fetch_all(
         return await cur.fetchall()  # type: ignore[return-value]
 
 
+async def fetch_all_with_setting(
+    setting: str,
+    value: str,
+    sql: str,
+    params: tuple | dict | None = None,
+) -> list[dict[str, Any]]:
+    """Run `sql` with a Postgres setting applied for that statement only.
+
+    The setting has to be applied on the same connection that runs the query,
+    which `fetch_all` cannot do — it takes a connection from the pool, runs one
+    statement and hands it back, so a separate `SET LOCAL` call would land on a
+    different connection and be silently lost.
+
+    `set_config(..., is_local => true)` scopes the value to the surrounding
+    transaction, so it is discarded when this connection returns to the pool
+    rather than leaking into whatever query borrows it next. Verified: a
+    following pooled call reads the server default again.
+
+    `set_config` is used rather than `SET LOCAL` because the value goes through
+    as a bound parameter. `SET LOCAL` only accepts a literal, which would mean
+    interpolating a caller-supplied value into SQL.
+    """
+    pool = await get_pool()
+    async with pool.connection() as conn:
+        await conn.execute("SELECT set_config(%s, %s, true)", (setting, value))
+        cur = await conn.execute(sql, params)
+        return await cur.fetchall()  # type: ignore[return-value]
+
+
 async def has_column(table: str, column: str) -> bool:
     """
     Whether `column` exists on `table` in the connected database.

--- a/src/memory_vault/services/search.py
+++ b/src/memory_vault/services/search.py
@@ -18,7 +18,12 @@ from datetime import UTC, datetime
 from typing import Any
 
 from memory_vault.config import settings
-from memory_vault.models.db import execute_query, fetch_all, fetch_one
+from memory_vault.models.db import (
+    execute_query,
+    fetch_all,
+    fetch_all_with_setting,
+    fetch_one,
+)
 from memory_vault.services.embedding import _get_model, embed, embed_batch
 
 logger = logging.getLogger(__name__)
@@ -157,6 +162,14 @@ _FTS_WEIGHT = 0.5
 _IMPORTANCE_WEIGHT = 0.15
 _RECENCY_HALF_LIFE_DAYS = 90
 _RECENCY_MAX_BOOST = 0.05
+
+# HNSW search breadth. Higher values search more of the index, trading latency
+# for recall; the server default is 40. The ceiling is not pgvector's limit
+# (1000) but a practical one: this is a knob a caller can set per request, and
+# a large value turns one search into a slow scan. Capping it keeps a careless
+# or hostile caller from doing that to an instance.
+_EF_SEARCH_MIN = 1
+_EF_SEARCH_MAX = 1000
 
 
 @dataclass
@@ -306,9 +319,16 @@ async def hybrid_search(
     limit: int | None = None,
     *,
     enrich: bool = True,
+    ef_search: int | None = None,
 ) -> tuple[list[SearchResult], list[str], int]:
     """
     Hybrid search: vector (HNSW) + full-text (tsvector GIN) + RRF merging.
+
+    `ef_search` raises HNSW's search breadth for this query only, trading
+    latency for recall on a corpus where the default misses relevant matches.
+    None leaves the server default (40) alone; out-of-range values are clamped
+    rather than rejected, since this is a tuning hint and not a correctness
+    input.
 
     Returns: (results, query_variations, elapsed_ms)
     """
@@ -375,7 +395,13 @@ async def hybrid_search(
         FROM ({vec_sql}) AS deduped
     """  # nosec B608
 
-    vec_rows = await fetch_all(vec_sql, tuple(vec_params))
+    if ef_search is None:
+        vec_rows = await fetch_all(vec_sql, tuple(vec_params))
+    else:
+        clamped = max(_EF_SEARCH_MIN, min(int(ef_search), _EF_SEARCH_MAX))
+        vec_rows = await fetch_all_with_setting(
+            "hnsw.ef_search", str(clamped), vec_sql, tuple(vec_params)
+        )
 
     # --- Arm 2: Full-text search ---
 

--- a/tests/test_ef_search.py
+++ b/tests/test_ef_search.py
@@ -1,0 +1,152 @@
+"""
+`ef_search` as a per-query knob.
+
+HNSW trades recall for speed: the index is searched to a breadth set by
+`hnsw.ef_search`, default 40. On a large or noisy corpus that default can miss
+matches a wider search would find, and there was no way to ask for a wider one
+without changing the server default for everybody.
+
+The setting has to be applied on the same connection that runs the query.
+`fetch_all` takes a connection from the pool, runs one statement and hands it
+back, so a separate `SET LOCAL` would land on a different connection and be
+silently lost — the query would run at the default while appearing to honour
+the request. `fetch_all_with_setting` is what makes it actually apply.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from memory_vault.models.db import fetch_all, fetch_all_with_setting
+from memory_vault.services.search import _EF_SEARCH_MAX, _EF_SEARCH_MIN
+
+pytestmark = pytest.mark.asyncio
+
+SERVER_DEFAULT = "40"
+
+
+class TestSettingIsAppliedAndScoped:
+    async def test_setting_applies_to_the_statement(self):
+        rows = await fetch_all_with_setting("hnsw.ef_search", "250", "SHOW hnsw.ef_search")
+        assert rows[0]["hnsw.ef_search"] == "250"
+
+    async def test_setting_does_not_leak_to_later_queries(self):
+        """
+        The reason this uses set_config(..., local => true) rather than a
+        session SET. Connections are pooled, so a session-scoped setting stays
+        on the connection and silently changes whatever query borrows it next.
+
+        Checked repeatedly rather than once, and that detail matters: the pool
+        holds several connections, so a single check can land on a clean one
+        and pass while a poisoned connection is still in rotation. Verified by
+        mutation — with `local => false` a single check passed and the leak
+        only showed on the second borrow.
+        """
+        await fetch_all_with_setting("hnsw.ef_search", "500", "SHOW hnsw.ef_search")
+
+        seen = set()
+        for _ in range(10):
+            rows = await fetch_all("SHOW hnsw.ef_search")
+            seen.add(rows[0]["hnsw.ef_search"])
+
+        assert seen == {SERVER_DEFAULT}, (
+            f"the setting leaked into pooled connections: saw {sorted(seen)}"
+        )
+
+    async def test_value_is_bound_not_interpolated(self):
+        """
+        `SET LOCAL` only accepts a literal, which would mean putting a
+        caller-supplied value into SQL text. set_config takes it as a
+        parameter, so a hostile value is data rather than syntax.
+        """
+        with pytest.raises(Exception):  # noqa: B017 - any DB error proves it was not executed
+            await fetch_all_with_setting(
+                "hnsw.ef_search", "40; DROP TABLE chunks", "SHOW hnsw.ef_search"
+            )
+
+        rows = await fetch_all("SELECT to_regclass('public.chunks') AS t")
+        assert rows[0]["t"] is not None, "chunks must still exist"
+
+
+class TestSearchAcceptsTheKnob:
+    async def _seed(self, client, auth_headers, space: str):
+        await client.post("/api/spaces", json={"name": space}, headers=auth_headers)
+        await client.post(
+            "/api/ingest/text",
+            json={
+                "text": "Hybrid search combines vector similarity and full-text retrieval.",
+                "space": space,
+            },
+            headers=auth_headers,
+        )
+
+    @pytest.mark.parametrize("ef", [None, 1, 100, 1000])
+    async def test_valid_values_are_accepted(self, client, auth_headers, ef):
+        await self._seed(client, auth_headers, "ef1")
+        body = {"query": "hybrid search", "spaces": ["ef1"], "limit": 3}
+        if ef is not None:
+            body["ef_search"] = ef
+
+        resp = await client.post("/api/search", json=body, headers=auth_headers)
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["results"], "the seeded memory should still be found"
+
+    @pytest.mark.parametrize("bad", [0, -1, 1001, 100_000])
+    async def test_out_of_range_is_rejected(self, client, auth_headers, bad):
+        """
+        Bounded at the API boundary so a caller gets told, rather than having a
+        silly value quietly clamped. A huge value is a slow scan on the
+        operator's own instance.
+        """
+        resp = await client.post(
+            "/api/search",
+            json={"query": "anything", "ef_search": bad},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 422
+
+    async def test_omitting_it_changes_nothing(self, client, auth_headers):
+        """The default path must be untouched — every existing caller omits it."""
+        await self._seed(client, auth_headers, "ef2")
+
+        without = await client.post(
+            "/api/search",
+            json={"query": "hybrid search", "spaces": ["ef2"], "limit": 3},
+            headers=auth_headers,
+        )
+        with_default = await client.post(
+            "/api/search",
+            json={"query": "hybrid search", "spaces": ["ef2"], "limit": 3, "ef_search": 40},
+            headers=auth_headers,
+        )
+
+        assert without.status_code == with_default.status_code == 200
+        assert [r["chunk_id"] for r in without.json()["results"]] == [
+            r["chunk_id"] for r in with_default.json()["results"]
+        ], "explicitly passing the server default should match omitting it"
+
+
+class TestServiceClamps:
+    """
+    The API rejects out-of-range values, but `hybrid_search` is also called
+    directly — from MCP `recall`, and from anything built on the service. It
+    clamps rather than raising, because a tuning hint should not fail a search.
+    """
+
+    async def test_bounds_are_sane(self):
+        assert _EF_SEARCH_MIN == 1
+        assert _EF_SEARCH_MAX == 1000
+
+    async def test_service_clamps_instead_of_failing(self, client, auth_headers):
+        from memory_vault.services.search import hybrid_search
+
+        await client.post("/api/spaces", json={"name": "ef3"}, headers=auth_headers)
+        await client.post(
+            "/api/ingest/text",
+            json={"text": "A memory for the clamping test.", "space": "ef3"},
+            headers=auth_headers,
+        )
+
+        for wild in (-5, 0, 99_999):
+            results, _, _ = await hybrid_search(query_text="clamping test", ef_search=wild)
+            assert isinstance(results, list), f"ef_search={wild} should not raise"


### PR DESCRIPTION
HNSW trades recall for speed: the index is searched to a breadth set by `hnsw.ef_search`, which defaults to 40. On a large or noisy corpus that default can miss matches a wider search would find, and there was no way to ask for a wider one without changing the server default for every query.

`POST /api/search` now takes an optional `ef_search`, and so does the MCP `recall` tool. Omitting it leaves the default alone, so every existing caller is unaffected.

## The part that isn't obvious

The setting has to be applied on the same connection that runs the query. `fetch_all` takes a connection from the pool, runs one statement, and hands it back — so a separate `SET LOCAL` call would land on a *different* connection and be silently lost. The query would run at the default while appearing to honour the request.

`fetch_all_with_setting` applies both on one connection.

It uses `set_config(..., is_local => true)` rather than `SET LOCAL` for two reasons:

- **The value is a bound parameter.** `SET LOCAL` only accepts a literal, which would mean interpolating a caller-supplied value into SQL.
- **The local scope keeps it off the pool.** Connections are reused, so a session-scoped setting would ride along into whatever query borrowed that connection next.

## Bounds

1–1000. The API rejects out-of-range values with a 422, so a caller is told rather than silently clamped. The service clamps instead of raising, because `hybrid_search` is also called directly and a tuning hint should not fail a search.

A large value is a slow scan on the operator's own instance, which is what the ceiling is for.

## Testing

14 tests: the setting applies, does not leak, is bound rather than interpolated; valid values are accepted across the range; out-of-range is a 422; omitting it returns identical results to passing the server default; and the service clamps rather than raising.

One of these was wrong on the first attempt, and the mutation run is what exposed it. The leak test originally checked a single query after the setting was applied. With `is_local => false` it still passed — the pool holds several connections, and that one check happened to land on a clean one while a poisoned connection was still in rotation. It now checks repeatedly, and fails as it should when the scope is wrong.

Full suite 494 passed, `ruff check` and `ruff format --check` clean.

Suggested by Rivestack.
