### PR TITLE
Warm the vector index on start-up

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -32,6 +32,13 @@ done
 echo "Running migrations..."
 memory-vault migrate
 
+# Page the vector index in, so the first real search is not the one that pays
+# to read it off disk. `|| true` is belt and braces: the command already
+# swallows its own failures, but this script runs under `set -e` and warming is
+# an optimisation, never a reason to refuse to start.
+echo "Warming vector index..."
+memory-vault warm-index || true
+
 # Show status
 echo ""
 memory-vault status

--- a/src/memory_vault/cli.py
+++ b/src/memory_vault/cli.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import sys
+import time
 
 from memory_vault.logging_config import configure_logging
 
@@ -46,6 +47,12 @@ def main() -> None:
 
     # migrate
     sub.add_parser("migrate", help="Run database migrations")
+
+    # warm-index
+    sub.add_parser(
+        "warm-index",
+        help="Touch the vector index so the first real search does not page it in",
+    )
 
     # purge-forgotten
     p_purge = sub.add_parser(
@@ -114,6 +121,8 @@ def main() -> None:
 
     if args.command == "migrate":
         asyncio.run(_cmd_migrate())
+    elif args.command == "warm-index":
+        asyncio.run(_cmd_warm_index())
     elif args.command == "purge-forgotten":
         asyncio.run(_cmd_purge_forgotten(args.older_than))
     elif args.command == "ingest":
@@ -146,6 +155,49 @@ def main() -> None:
         from memory_vault.diagnose import cli_diagnose
 
         cli_diagnose(Path(args.out_dir) if args.out_dir else None)
+
+
+# Named rather than inlined so the test can EXPLAIN the exact statement the
+# command runs. Asserting on a copy of the SQL would keep passing if this one
+# stopped using the index.
+WARM_INDEX_SQL = "SELECT id FROM chunks ORDER BY embedding <=> %s::vector LIMIT 1"
+
+
+async def _cmd_warm_index() -> None:
+    """Run one nearest-neighbour query so the HNSW index is paged in.
+
+    Without this the first real search after a start pays to read the index off
+    disk, which on a large corpus is the slowest query anyone will run — and it
+    lands on a user rather than on start-up.
+
+    A KNN query is used rather than `pg_prewarm`, which is available in the
+    pgvector image but not installed: using it would mean CREATE EXTENSION,
+    which the least-privilege application role cannot do. This needs no
+    privileges beyond the SELECT the app already has.
+
+    Never fails the caller. Warming is an optimisation, and a container that
+    refuses to start because an optimisation did not work is worse than a
+    slightly slow first query. `scripts/start.sh` relies on that.
+    """
+    from memory_vault.config import settings
+    from memory_vault.models.db import close_pool, fetch_all, init_pool
+
+    try:
+        await init_pool()
+    except Exception as e:
+        print(f"Index warm-up skipped (database unavailable): {e}")
+        return
+
+    try:
+        zero_vector = "[" + ",".join(["0"] * settings.embedding_dimensions) + "]"
+        start = time.perf_counter()
+        await fetch_all(WARM_INDEX_SQL, (zero_vector,))
+        elapsed_ms = int((time.perf_counter() - start) * 1000)
+        print(f"Vector index warmed in {elapsed_ms} ms.")
+    except Exception as e:
+        print(f"Index warm-up skipped: {e}")
+    finally:
+        await close_pool()
 
 
 async def _cmd_purge_forgotten(older_than_days: int) -> None:

--- a/tests/test_warm_index.py
+++ b/tests/test_warm_index.py
@@ -1,0 +1,162 @@
+"""
+Vector index warm-up.
+
+Without this the first real search after a start pays to read the HNSW index
+off disk — on a large corpus that is the slowest query anyone will run, and it
+lands on a user rather than on start-up.
+
+The property that matters more than the speed-up: warming must never stop the
+process from starting. It is an optimisation, and a container that refuses to
+boot because an optimisation failed is worse than a slow first query.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from memory_vault.cli import WARM_INDEX_SQL, _cmd_warm_index
+from memory_vault.models.db import fetch_all
+
+
+@pytest.fixture
+def keep_pool_open(monkeypatch):
+    """
+    `_cmd_warm_index` closes the pool in its `finally`. That is right for a
+    one-shot CLI command and wrong to let happen here: conftest opens a single
+    pool for the whole session, so a real close ends the suite — every
+    subsequent test errors with `PoolClosed` in the truncate fixture.
+
+    So the close is intercepted and recorded rather than performed. The
+    recording is what the closing test asserts on; the interception is what
+    keeps the rest of the suite alive.
+    """
+    from memory_vault.models import db as db_mod
+
+    calls: list[str] = []
+
+    async def _record_close():
+        calls.append("close_pool")
+
+    monkeypatch.setattr(db_mod, "close_pool", _record_close)
+    return calls
+
+
+class TestWarmingTouchesTheIndex:
+    async def test_the_index_exists_to_be_warmed(self):
+        """If the index is ever renamed, the warm query stops being useful."""
+        rows = await fetch_all(
+            "SELECT indexname FROM pg_indexes WHERE indexname = 'chunks_embedding_idx'"
+        )
+        assert rows, "chunks_embedding_idx is what the warm query is meant to page in"
+
+    async def test_the_warm_query_actually_uses_the_index(self):
+        """
+        A query that reads the table but not the index would warm nothing —
+        and would look identical from the outside, since it succeeds, prints a
+        timing and returns no rows on an empty corpus. The plan is the only
+        thing that distinguishes them.
+
+        EXPLAINs `WARM_INDEX_SQL` itself rather than a copy: an earlier version
+        of this test pasted the query in, and a mutation that made the real one
+        stop using the index left it passing.
+        """
+        from memory_vault.config import settings
+
+        zero = "[" + ",".join(["0"] * settings.embedding_dimensions) + "]"
+        rows = await fetch_all(f"EXPLAIN {WARM_INDEX_SQL}", (zero,))
+        plan = " ".join(r["QUERY PLAN"] for r in rows)
+        assert "chunks_embedding_idx" in plan, f"warm query did not use the index:\n{plan}"
+
+    async def test_warming_works_on_an_empty_corpus(self, keep_pool_open, capsys):
+        """
+        A fresh install has no chunks. Warming must be a no-op there, not an
+        error — this runs on every start, including the first.
+        """
+        await _cmd_warm_index()
+
+        out = capsys.readouterr().out
+        assert "Vector index warmed in" in out, f"expected a successful warm, got: {out!r}"
+        assert "skipped" not in out
+
+
+class TestWarmingNeverBlocksStartup:
+    """
+    `scripts/start.sh` runs under `set -e`. If this command raised or exited
+    non-zero, a failed warm-up would stop the container from starting.
+    """
+
+    async def test_database_unavailable_is_survived(self, monkeypatch, keep_pool_open, capsys):
+        """The container starting before Postgres accepts connections."""
+        from memory_vault.models import db as db_mod
+
+        async def _refuse(*args, **kwargs):
+            raise OSError("connection refused")
+
+        monkeypatch.setattr(db_mod, "init_pool", _refuse)
+
+        await _cmd_warm_index()  # must return, not raise
+
+        out = capsys.readouterr().out
+        assert "database unavailable" in out
+        assert "connection refused" in out, "the operator should see why it was skipped"
+
+    async def test_query_failure_is_survived(self, monkeypatch, keep_pool_open, capsys):
+        """
+        The pool opens but the query fails — a missing table during a partial
+        migration, a permissions problem, a statement timeout.
+        """
+        from memory_vault.models import db as db_mod
+
+        async def _explode(*args, **kwargs):
+            raise RuntimeError('relation "chunks" does not exist')
+
+        monkeypatch.setattr(db_mod, "fetch_all", _explode)
+
+        await _cmd_warm_index()  # must return, not raise
+
+        out = capsys.readouterr().out
+        assert "Index warm-up skipped" in out
+        assert "does not exist" in out
+
+    async def test_pool_is_closed_even_when_the_query_fails(self, monkeypatch, keep_pool_open):
+        """
+        Leaking a pool on every failed start would exhaust connections on a
+        crash-looping container.
+        """
+        from memory_vault.models import db as db_mod
+
+        async def _explode(*args, **kwargs):
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(db_mod, "fetch_all", _explode)
+
+        await _cmd_warm_index()
+
+        assert keep_pool_open == ["close_pool"], (
+            "the pool must be closed exactly once, even on the failure path"
+        )
+
+
+class TestStartupScript:
+    """The command is only useful if start.sh actually calls it."""
+
+    def test_start_sh_warms_after_migrating(self):
+        from pathlib import Path
+
+        script = (Path(__file__).resolve().parent.parent / "scripts" / "start.sh").read_text()
+
+        assert "memory-vault warm-index" in script, "start.sh should warm the index"
+
+        migrate_at = script.index("memory-vault migrate")
+        warm_at = script.index("memory-vault warm-index")
+        assert migrate_at < warm_at, "warming must come after migrations create the index"
+
+    def test_start_sh_does_not_let_warming_fail_the_boot(self):
+        from pathlib import Path
+
+        script = (Path(__file__).resolve().parent.parent / "scripts" / "start.sh").read_text()
+
+        warm_line = next(line for line in script.splitlines() if "memory-vault warm-index" in line)
+        assert "|| true" in warm_line, (
+            "start.sh runs under set -e; the warm call needs an explicit guard"
+        )


### PR DESCRIPTION
## What

Adds `memory-vault warm-index`, and calls it from `scripts/start.sh` after migrations.

## Why

The first search after a container start pays to read the HNSW index off disk. On a large corpus that is the slowest query anyone will run, and it lands on a user rather than on start-up.

## How

One nearest-neighbour query against `chunks_embedding_idx`. `EXPLAIN` confirms it plans as `Index Scan using chunks_embedding_idx on chunks`.

Not `pg_prewarm`: it ships in the `pgvector/pgvector:pg16` image but is not installed (`SELECT installed_version IS NOT NULL FROM pg_available_extensions WHERE name='pg_prewarm'` returns false), and installing it needs `CREATE EXTENSION`, which the least-privilege application role deliberately cannot do. A KNN query needs no privilege beyond the `SELECT` the app already has.

**It never fails the caller.** A database that is not accepting connections yet, a partial migration, a statement timeout — each is reported and swallowed. `start.sh` guards the call with `|| true` as well, since it runs under `set -e`. Warming is an optimisation; a container that refuses to start because an optimisation failed is worse than a slow first query.

## Tests

8 new tests (502 total, all passing in the containerized suite):

- the index exists, and the warm query plans as an index scan
- warming succeeds on an empty corpus — a fresh install has no chunks
- an unreachable database is survived, and says why
- a failing query is survived, and says why
- the pool is closed even on the failure path
- `start.sh` warms after migrating, and guards the call

Each was mutation-tested. One mutation exposed a real weakness: the plan assertion originally EXPLAINed a pasted copy of the SQL, so it kept passing when the query the code runs stopped using the index. The query is now a named constant the test imports.

Verified end to end in a container — `Running migrations... / Warming vector index... / Vector index warmed in 1 ms.` — and with the database down, where start-up continues normally.

Suggested by Rivestack.
