### PR TITLE
Filter the graph by several entity types at once

### DIFF
--- a/src/memory_vault/api/routers/graph.py
+++ b/src/memory_vault/api/routers/graph.py
@@ -25,6 +25,42 @@ router = APIRouter(prefix="/api/graph", tags=["graph"], dependencies=[Depends(re
 
 CHUNK_PREVIEW_LEN = 200
 
+# An upper bound on how many types one request may filter by. There are four
+# entity types today, but relationship types are free-form strings written by
+# the extractor, so this is not a small closed set. The cap keeps a hostile
+# caller from sending a megabyte of comma-separated values.
+MAX_TYPE_FILTERS = 50
+
+
+def parse_type_filter(raw: str | None) -> list[str] | None:
+    """Split a comma-separated `type` parameter into the types to filter by.
+
+    `?type=Person` and `?type=Person,Tool` are both valid; the single-value
+    form is just a list of one, so every existing caller keeps working and
+    there is one code path rather than two.
+
+    Returns None when there is nothing to filter by — no parameter at all, or
+    a value that is empty once separators and whitespace are removed. That is
+    deliberately the same as omitting it: `?type=` and `?type=,,` mean "no type
+    filter", not "match the empty type", which no entity has.
+
+    Duplicates are collapsed and order is preserved, so `?type=Tool,Tool`
+    binds one value rather than making the array grow with repetition.
+    """
+    if raw is None:
+        return None
+
+    seen: dict[str, None] = {}
+    for part in raw.split(","):
+        cleaned = part.strip()
+        if cleaned:
+            seen[cleaned] = None
+
+    if not seen:
+        return None
+
+    return list(seen)[:MAX_TYPE_FILTERS]
+
 
 # ---------------------------------------------------------------------------
 # /entities  —  paginated list
@@ -34,7 +70,10 @@ CHUNK_PREVIEW_LEN = 200
 @router.get("/entities", response_model=EntityList)
 async def list_entities(
     space: str | None = Query(default=None, description="Filter by space name."),
-    type: str | None = Query(default=None, description="Filter by entity type."),
+    type: str | None = Query(
+        default=None,
+        description="Filter by entity type. Comma-separated for several: Person,Tool",
+    ),
     min_mentions: int = Query(default=1, ge=1),
     limit: int = Query(default=50, ge=1, le=500),
     offset: int = Query(default=0, ge=0),
@@ -45,15 +84,17 @@ async def list_entities(
     if space is not None:
         where.append("ms.name = %s")
         params.append(space)
-    if type is not None:
-        where.append("e.type = %s")
-        params.append(type)
+    types = parse_type_filter(type)
+    if types is not None:
+        where.append("e.type = ANY(%s)")
+        params.append(types)
 
     where_sql = " AND ".join(where) if where else "TRUE"
 
     # nosec B608 — `where_sql` is composed from a closed list of literal
-    # templates ("ms.name = %s", "e.type = %s"). User values go through %s
-    # parameters in `params`. No user-controlled SQL fragments.
+    # templates ("ms.name = %s", "e.type = ANY(%s)"). User values go through %s
+    # parameters in `params`; the type filter binds a list, so the number of
+    # values never changes the SQL text. No user-controlled SQL fragments.
     # Subquery builds entity + mention_count, then filters by min_mentions.
     # Reading mentions through live_entity_mentions keeps forgotten chunks out
     # of the count, so entities with zero live mentions drop out via HAVING.
@@ -179,7 +220,12 @@ async def get_entity(entity_id: UUID) -> EntityDetail:
 @router.get("/relationships", response_model=RelationshipList)
 async def list_relationships(
     entity_id: str | None = Query(default=None, description="Either source or target."),
-    type: str | None = Query(default=None, description="Filter by relationship type."),
+    type: str | None = Query(
+        default=None,
+        description=(
+            "Filter by relationship type. Comma-separated for several: works_on,related_to"
+        ),
+    ),
     space: str | None = Query(default=None, description="Filter by chunk's space."),
     limit: int = Query(default=50, ge=1, le=500),
     offset: int = Query(default=0, ge=0),
@@ -193,9 +239,10 @@ async def list_relationships(
     if entity_id is not None:
         where.append("(r.source_entity_id = %s OR r.target_entity_id = %s)")
         params.extend([entity_id, entity_id])
-    if type is not None:
-        where.append("r.type = %s")
-        params.append(type)
+    types = parse_type_filter(type)
+    if types is not None:
+        where.append("r.type = ANY(%s)")
+        params.append(types)
     if space is not None:
         where.append(
             "r.chunk_id IN (SELECT c.id FROM chunks c "
@@ -251,7 +298,10 @@ async def list_relationships(
 @router.get("/visualize", response_model=GraphVisualization)
 async def visualize(
     space: str | None = Query(default=None),
-    type: str | None = Query(default=None),
+    type: str | None = Query(
+        default=None,
+        description="Filter by entity type. Comma-separated for several: Person,Tool",
+    ),
     min_mentions: int = Query(default=1, ge=1),
     max_nodes: int = Query(default=100, ge=1, le=500),
 ) -> GraphVisualization:
@@ -261,9 +311,10 @@ async def visualize(
     if space is not None:
         where.append("ms.name = %s")
         params.append(space)
-    if type is not None:
-        where.append("e.type = %s")
-        params.append(type)
+    types = parse_type_filter(type)
+    if types is not None:
+        where.append("e.type = ANY(%s)")
+        params.append(types)
 
     where_sql = " AND ".join(where) if where else "TRUE"
 

--- a/tests/test_graph_type_multiselect.py
+++ b/tests/test_graph_type_multiselect.py
@@ -1,0 +1,284 @@
+"""
+Multi-select type filtering on the graph endpoints.
+
+`?type=Person` filtered by one entity type and there was no way to ask for
+two. Selecting "Person" and "Tool" on the graph meant two requests and no way
+to see both at once.
+
+All three graph endpoints now split a comma-separated `type`. The single-value
+form is a list of one, so every existing caller keeps working through the same
+code path rather than a preserved special case.
+
+`/relationships` filters relationship type, not entity type — a different
+vocabulary (`works_on`, not `Person`), which is why it is tested separately
+rather than parametrized alongside the other two.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from memory_vault.api.routers.graph import MAX_TYPE_FILTERS, parse_type_filter
+from memory_vault.models.db import execute_query, fetch_one
+
+
+async def _seed_space(name: str) -> int:
+    row = await fetch_one(
+        "INSERT INTO memory_spaces (name) VALUES (%s) "
+        "ON CONFLICT (name) DO UPDATE SET name = EXCLUDED.name RETURNING id",
+        (name,),
+    )
+    return row["id"]
+
+
+async def _seed_chunk(space_id: int) -> str:
+    row = await fetch_one(
+        "INSERT INTO chunks (space_id, content, chunk_index) VALUES (%s, 'seed', 0) RETURNING id",
+        (space_id,),
+    )
+    return str(row["id"])
+
+
+async def _seed_entity(space_id: int, name: str, ent_type: str) -> str:
+    row = await fetch_one(
+        "INSERT INTO entities (name, type, space_id) VALUES (%s, %s, %s) RETURNING id",
+        (name, ent_type, space_id),
+    )
+    return str(row["id"])
+
+
+async def _seed_mention(entity_id: str, chunk_id: str) -> None:
+    await execute_query(
+        "INSERT INTO entity_mentions (entity_id, chunk_id, start_offset, end_offset) "
+        "VALUES (%s, %s, 0, 5)",
+        (entity_id, chunk_id),
+    )
+
+
+async def _seed_one_of_each(space_name: str) -> dict[str, str]:
+    """One live entity per type, each with a mention so it survives min_mentions."""
+    space_id = await _seed_space(space_name)
+    chunk_id = await _seed_chunk(space_id)
+
+    ids = {}
+    for ent_type in ("Person", "Project", "Tool", "Concept"):
+        entity_id = await _seed_entity(space_id, f"{ent_type}Name", ent_type)
+        await _seed_mention(entity_id, chunk_id)
+        ids[ent_type] = entity_id
+    return ids
+
+
+class TestParser:
+    """
+    The parsing is shared by all three endpoints, so its edges are worth
+    pinning directly rather than only through HTTP.
+    """
+
+    def test_absent_means_no_filter(self):
+        assert parse_type_filter(None) is None
+
+    @pytest.mark.parametrize("raw", ["", "   ", ",", ",,,", " , , "])
+    def test_empty_means_no_filter_not_match_nothing(self, raw):
+        """
+        `?type=` reaches here as an empty string — the web client sends exactly
+        that when the array of selected types is empty, because URLSearchParams
+        keeps the key. Treating it as "match the empty type" would return
+        nothing at all, which is not what an empty selection means.
+        """
+        assert parse_type_filter(raw) is None
+
+    def test_single_value_is_a_list_of_one(self):
+        assert parse_type_filter("Person") == ["Person"]
+
+    def test_several_values_split(self):
+        assert parse_type_filter("Person,Tool") == ["Person", "Tool"]
+
+    def test_whitespace_around_values_is_ignored(self):
+        assert parse_type_filter(" Person , Tool ") == ["Person", "Tool"]
+
+    def test_empty_segments_are_dropped(self):
+        assert parse_type_filter("Person,,Tool") == ["Person", "Tool"]
+
+    def test_duplicates_collapse_and_order_is_kept(self):
+        assert parse_type_filter("Person,Tool,Person") == ["Person", "Tool"]
+
+    def test_a_hostile_number_of_values_is_capped(self):
+        """
+        Distinct values, because duplicates collapse before the cap applies —
+        a probe with 60 identical values returned one item and proved nothing
+        about the cap.
+        """
+        raw = ",".join(f"T{i}" for i in range(5_000))
+        assert len(parse_type_filter(raw)) == MAX_TYPE_FILTERS
+
+
+class TestEntitiesEndpoint:
+    async def test_single_type_still_works(self, client, auth_headers):
+        """The form every existing caller uses."""
+        await _seed_one_of_each("mt1")
+
+        r = await client.get("/api/graph/entities?space=mt1&type=Tool", headers=auth_headers)
+        assert r.status_code == 200, r.text
+        assert {e["type"] for e in r.json()["entities"]} == {"Tool"}
+
+    async def test_two_types_return_both(self, client, auth_headers):
+        await _seed_one_of_each("mt2")
+
+        r = await client.get("/api/graph/entities?space=mt2&type=Person,Tool", headers=auth_headers)
+        assert r.status_code == 200, r.text
+        assert {e["type"] for e in r.json()["entities"]} == {"Person", "Tool"}
+
+    async def test_the_union_is_wider_than_either_part(self, client, auth_headers):
+        """
+        Guards against a filter that silently matches everything: the pair must
+        return more than one type alone, and still fewer than no filter at all.
+        """
+        await _seed_one_of_each("mt3")
+
+        async def _count(query: str) -> int:
+            r = await client.get(f"/api/graph/entities?space=mt3{query}", headers=auth_headers)
+            assert r.status_code == 200, r.text
+            return r.json()["total"]
+
+        one = await _count("&type=Person")
+        two = await _count("&type=Person,Tool")
+        all_types = await _count("")
+
+        assert one == 1
+        assert two == 2
+        assert all_types == 4
+        assert one < two < all_types
+
+    async def test_empty_value_means_all_types(self, client, auth_headers):
+        """`?type=` is what the web client sends with nothing selected."""
+        await _seed_one_of_each("mt4")
+
+        r = await client.get("/api/graph/entities?space=mt4&type=", headers=auth_headers)
+        assert r.status_code == 200, r.text
+        assert r.json()["total"] == 4
+
+    async def test_an_unknown_type_matches_nothing(self, client, auth_headers):
+        await _seed_one_of_each("mt5")
+
+        r = await client.get("/api/graph/entities?space=mt5&type=Nope", headers=auth_headers)
+        assert r.status_code == 200, r.text
+        assert r.json()["total"] == 0
+
+    async def test_a_known_type_alongside_an_unknown_one_still_matches(self, client, auth_headers):
+        await _seed_one_of_each("mt6")
+
+        r = await client.get("/api/graph/entities?space=mt6&type=Nope,Tool", headers=auth_headers)
+        assert r.status_code == 200, r.text
+        assert {e["type"] for e in r.json()["entities"]} == {"Tool"}
+
+
+class TestVisualizeEndpoint:
+    async def test_single_type_still_works(self, client, auth_headers):
+        await _seed_one_of_each("mv1")
+
+        r = await client.get("/api/graph/visualize?space=mv1&type=Tool", headers=auth_headers)
+        assert r.status_code == 200, r.text
+        assert {n["type"] for n in r.json()["nodes"]} == {"Tool"}
+
+    async def test_two_types_return_both(self, client, auth_headers):
+        await _seed_one_of_each("mv2")
+
+        r = await client.get(
+            "/api/graph/visualize?space=mv2&type=Person,Concept", headers=auth_headers
+        )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert {n["type"] for n in body["nodes"]} == {"Person", "Concept"}
+        assert body["node_count"] == 2
+
+    async def test_the_truncation_count_respects_the_filter(self, client, auth_headers):
+        """
+        `truncated` compares against a second COUNT query that has its own copy
+        of the WHERE clause. If the filter were applied to only one of them,
+        a filtered graph would claim to be truncated when it is not.
+        """
+        await _seed_one_of_each("mv3")
+
+        r = await client.get(
+            "/api/graph/visualize?space=mv3&type=Person,Tool", headers=auth_headers
+        )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["node_count"] == 2
+        assert body["truncated"] is False
+
+
+class TestRelationshipsEndpoint:
+    """Relationship types are free-form strings from the extractor, not the
+    four entity types — `works_on`, not `Person`."""
+
+    async def _seed_edges(self, space_name: str) -> None:
+        space_id = await _seed_space(space_name)
+        chunk_id = await _seed_chunk(space_id)
+        a = await _seed_entity(space_id, "Alice", "Person")
+        b = await _seed_entity(space_id, "Bob", "Person")
+
+        for rel_type in ("works_on", "related_to", "mentions"):
+            await execute_query(
+                "INSERT INTO relationships (source_entity_id, target_entity_id, type, chunk_id) "
+                "VALUES (%s, %s, %s, %s)",
+                (a, b, rel_type, chunk_id),
+            )
+
+    async def test_single_type_still_works(self, client, auth_headers):
+        await self._seed_edges("mr1")
+
+        r = await client.get(
+            "/api/graph/relationships?space=mr1&type=works_on", headers=auth_headers
+        )
+        assert r.status_code == 200, r.text
+        assert {x["type"] for x in r.json()["relationships"]} == {"works_on"}
+
+    async def test_two_types_return_both(self, client, auth_headers):
+        await self._seed_edges("mr2")
+
+        r = await client.get(
+            "/api/graph/relationships?space=mr2&type=works_on,mentions", headers=auth_headers
+        )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert {x["type"] for x in body["relationships"]} == {"works_on", "mentions"}
+        assert body["total"] == 2
+
+
+class TestValuesStayBound:
+    """
+    The three WHERE clauses are still composed by string interpolation, with a
+    `nosec B608` note saying the templates are literal and the values bound.
+    Switching to `= ANY(%s)` had to keep that true.
+    """
+
+    async def test_a_sql_payload_is_treated_as_a_type_name(self, client, auth_headers):
+        await _seed_one_of_each("mi1")
+
+        r = await client.get(
+            "/api/graph/entities",
+            params={"space": "mi1", "type": "Tool'; DROP TABLE entities; --"},
+            headers=auth_headers,
+        )
+        assert r.status_code == 200, r.text
+        assert r.json()["total"] == 0, "the payload should match no type, not execute"
+
+        still_there = await fetch_one("SELECT to_regclass('public.entities') AS t")
+        assert still_there["t"] is not None, "entities table must still exist"
+
+    async def test_a_payload_among_valid_types_does_not_change_the_others(
+        self, client, auth_headers
+    ):
+        await _seed_one_of_each("mi2")
+
+        r = await client.get(
+            "/api/graph/entities",
+            params={"space": "mi2", "type": "Tool,'); DELETE FROM entities; --"},
+            headers=auth_headers,
+        )
+        assert r.status_code == 200, r.text
+        assert {e["type"] for e in r.json()["entities"]} == {"Tool"}
+
+        remaining = await fetch_one("SELECT COUNT(*) AS n FROM entities")
+        assert int(remaining["n"]) >= 4, "no rows should have been deleted"

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -137,7 +137,11 @@ export interface EntityDetail {
 
 export interface GraphVisualizeParams {
   space?: string
-  type?: string
+  /**
+   * One entity type, or several. An array serialises comma-separated
+   * (`type=Person,Tool`), which is the form the backend splits on.
+   */
+  type?: string | string[]
   min_mentions?: number
   max_nodes?: number
 }

--- a/web/src/pages/Graph.tsx
+++ b/web/src/pages/Graph.tsx
@@ -40,6 +40,19 @@ export default function GraphPage() {
     setSearchParams(next, { replace: true })
   }
 
+  // `type` stays a comma-separated string in the URL and in the query key —
+  // the array is derived for rendering only. Keeping the string canonical
+  // means a shared link still works and the query key stays a stable scalar.
+  const selectedTypes = type ? type.split(',').filter(Boolean) : []
+
+  const toggleType = (t: string) => {
+    const next = selectedTypes.includes(t)
+      ? selectedTypes.filter((x) => x !== t)
+      : [...selectedTypes, t]
+    // Empty means "all types", which is the absent parameter.
+    updateFilters({ type: next.length ? next.join(',') : null })
+  }
+
   // Debounced copies for slider values — API call waits until user stops dragging.
   const [debouncedMinMentions, setDebouncedMinMentions] = useState(minMentions)
   const [debouncedMaxNodes, setDebouncedMaxNodes] = useState(maxNodes)
@@ -77,6 +90,8 @@ export default function GraphPage() {
         spaces={spacesQuery.data?.spaces ?? []}
         space={space}
         type={type}
+        selectedTypes={selectedTypes}
+        onToggleType={toggleType}
         minMentions={minMentions}
         maxNodes={maxNodes}
         onChange={updateFilters}
@@ -114,12 +129,23 @@ interface FilterBarProps {
   spaces: SpaceInfo[]
   space: string
   type: string
+  selectedTypes: string[]
+  onToggleType: (t: string) => void
   minMentions: number
   maxNodes: number
   onChange: (patch: Record<string, string | number | null>) => void
 }
 
-function FilterBar({ spaces, space, type, minMentions, maxNodes, onChange }: FilterBarProps) {
+function FilterBar({
+  spaces,
+  space,
+  type,
+  selectedTypes,
+  onToggleType,
+  minMentions,
+  maxNodes,
+  onChange,
+}: FilterBarProps) {
   return (
     <div className="bg-bg2 border border-border rounded-md p-3 flex flex-wrap items-center gap-4">
       <label className="flex items-center gap-2 text-sm text-text2">
@@ -138,21 +164,40 @@ function FilterBar({ spaces, space, type, minMentions, maxNodes, onChange }: Fil
         </select>
       </label>
 
-      <label className="flex items-center gap-2 text-sm text-text2">
+      {/*
+        Toggle chips rather than a native multi-select: there are four types,
+        each already has a colour on the graph, and a <select multiple> hides
+        the selection behind a scrollbox and needs ctrl-click to combine.
+        Selecting none means "all types" — the same as the old "All types"
+        option, and what the backend does with an absent filter.
+      */}
+      <div className="flex items-center gap-2 text-sm text-text2">
         Type
-        <select
-          value={type}
-          onChange={(e) => onChange({ type: e.target.value || null })}
-          className="bg-bg3 border border-border rounded-sm px-2 py-1 text-sm text-text"
-        >
-          <option value="">All types</option>
-          {ENTITY_TYPES.map((t) => (
-            <option key={t} value={t}>
-              {t}
-            </option>
-          ))}
-        </select>
-      </label>
+        <div className="flex flex-wrap gap-1.5">
+          {ENTITY_TYPES.map((t) => {
+            const active = selectedTypes.includes(t)
+            return (
+              <button
+                key={t}
+                type="button"
+                aria-pressed={active}
+                onClick={() => onToggleType(t)}
+                className={`flex items-center gap-1.5 rounded-sm border px-2 py-1 text-xs transition-colors ${
+                  active
+                    ? 'border-accent bg-bg3 text-text'
+                    : 'border-border text-text2 hover:text-text'
+                }`}
+              >
+                <span
+                  className="h-2 w-2 rounded-full"
+                  style={{ backgroundColor: TYPE_COLORS[t] ?? DEFAULT_COLOR }}
+                />
+                {t}
+              </button>
+            )
+          })}
+        </div>
+      </div>
 
       <label className="flex items-center gap-2 text-sm text-text2">
         Min mentions


### PR DESCRIPTION
## What

`?type=` on the three graph endpoints now accepts several comma-separated values: `?type=Person,Tool`. The Graph page filter becomes toggle chips instead of a single-value dropdown.

## Why

Selecting Person and Tool meant two requests and no way to see both at once.

## How

One shared `parse_type_filter` used by `/entities`, `/relationships` and `/visualize`.

- **A single value is a list of one**, so existing callers use the same code path rather than a preserved special case. Every pre-existing graph test passes unchanged.
- **`?type=` means all types**, not "match the empty type" — the web client sends exactly that when no chip is selected, and no entity has an empty type. Same for `?type=,,`.
- **Values are bound as an array** with `= ANY(%s)` rather than interpolated into an `IN` list, so the number of types never changes the SQL text. The `nosec B608` note on that query still named the old single-value template; it has been updated.
- **Duplicates collapse, order is preserved**, and the list is capped at 50 so a caller cannot send a megabyte of values.

`/relationships` filters *relationship* type (`works_on`), not entity type — a different vocabulary, so it is tested separately.

On the page, four toggle chips each carry that type's graph colour. A native `<select multiple>` hides the selection in a scrollbox and needs ctrl-click to combine, which fits four colour-coded options poorly. The URL keeps a comma-separated string, so a filtered graph is still shareable as a link.

## Tests

25 new (527 total, all passing):

- parser edges — absent, empty, whitespace, empty segments, duplicates, and the cap
- each endpoint with one type and with two
- the union is strictly wider than either type alone and narrower than no filter, so a filter that silently matched everything would fail
- `truncated` on `/visualize` respects the filter — that count is a second query with its own copy of the WHERE clause
- SQL payloads as type values are matched as data, and the `entities` table survives

Mutation-tested three ways: honouring only the first type (11 failures), treating empty as match-nothing (6), and interpolating the values instead of binding them (2 — and the injection test failed with `syntax error at or near ";"`, which is the payload reaching the SQL parser, so it discriminates for the right reason).

Also verified against a running server: `type=Person%2CTool` — the URL-encoded form the client actually sends — returns both types, and the injection payload returns an empty result with all rows intact.
