### PR TITLE
Upload several files in one request

### DIFF
--- a/src/memory_vault/api/routers/ingest.py
+++ b/src/memory_vault/api/routers/ingest.py
@@ -9,7 +9,12 @@ from pathlib import Path
 from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile, status
 
 from memory_vault.api.deps import require_token
-from memory_vault.api.schemas import IngestResponse, IngestTextRequest
+from memory_vault.api.schemas import (
+    IngestFileResult,
+    IngestFilesResponse,
+    IngestResponse,
+    IngestTextRequest,
+)
 from memory_vault.services.ingestion import IngestionPipeline, ingest_text
 from memory_vault.services.spaces import InvalidSpaceName, ensure_space
 
@@ -22,6 +27,35 @@ router = APIRouter(prefix="/api", tags=["ingest"], dependencies=[Depends(require
 # tempfile + pipeline memory bounded.
 MAX_UPLOAD_BYTES = 25 * 1024 * 1024
 _UPLOAD_CHUNK = 1024 * 1024  # 1 MB streaming reads
+
+# Batch limits. The per-file cap is the single-upload cap, unchanged — one
+# file should not become more permissive by arriving with company. The
+# aggregate cap is what stops fifty files of 24 MB each, and the file-count
+# cap stops ten thousand tiny ones, which is a different way to spend the
+# same afternoon.
+MAX_BATCH_FILES = 100
+MAX_BATCH_BYTES = 100 * 1024 * 1024
+
+# What a file is rejected for before anything is read. Kept as a message the
+# caller can act on, rather than the underlying exception.
+_EMPTY_FILE = "File is empty."
+_TOO_LARGE = f"File exceeds the {MAX_UPLOAD_BYTES // (1024 * 1024)} MB per-file limit."
+_BATCH_FULL = f"Skipped: the batch reached its {MAX_BATCH_BYTES // (1024 * 1024)} MB total limit."
+
+
+def _reject_bad_filename(filename: str) -> str | None:
+    """Return why `filename` is unusable, or None if it is fine.
+
+    Same rule as the single-file upload: the on-disk path is a tempfile we
+    control, so there is no real escape, but the name is echoed back and
+    stored as the chunk's source, and "../../etc/passwd" should not turn up
+    in the dashboard.
+    """
+    if not filename:
+        return "Missing filename."
+    if ".." in filename or "/" in filename or "\\" in filename or filename.startswith("."):
+        return "Invalid filename. Path separators and traversal patterns are not allowed."
+    return None
 
 
 async def _resolve_space_id(name: str) -> int:
@@ -102,7 +136,7 @@ async def ingest_file_endpoint(
                 bytes_written += len(chunk)
                 if bytes_written > MAX_UPLOAD_BYTES:
                     raise HTTPException(
-                        status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                        status_code=status.HTTP_413_CONTENT_TOO_LARGE,
                         detail=(
                             f"File too large. Maximum upload size is "
                             f"{MAX_UPLOAD_BYTES // (1024 * 1024)} MB."
@@ -154,4 +188,162 @@ async def ingest_file_endpoint(
 
     finally:
         if tmp_path:
+            Path(tmp_path).unlink(missing_ok=True)
+
+
+async def _spool_upload(
+    file: UploadFile, remaining_budget: int
+) -> tuple[str | None, int, str | None]:
+    """Stream one upload to a tempfile.
+
+    Returns (temp path, bytes written, rejection reason). Exactly one of the
+    path or the reason is set. Streamed rather than read whole so a large
+    upload is rejected while it arrives instead of after it has been held in
+    memory — and in a batch that matters more, since several could arrive at
+    once.
+    """
+    filename = file.filename or ""
+    suffix = Path(filename).suffix or ".txt"
+
+    written = 0
+    tmp_path: str | None = None
+    try:
+        with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tmp:
+            tmp_path = tmp.name
+            while True:
+                blob = await file.read(_UPLOAD_CHUNK)
+                if not blob:
+                    break
+                written += len(blob)
+                if written > MAX_UPLOAD_BYTES:
+                    Path(tmp_path).unlink(missing_ok=True)
+                    return None, 0, _TOO_LARGE
+                if written > remaining_budget:
+                    Path(tmp_path).unlink(missing_ok=True)
+                    return None, 0, _BATCH_FULL
+                tmp.write(blob)
+    except OSError:
+        if tmp_path:
+            Path(tmp_path).unlink(missing_ok=True)
+        logger.exception("Failed to spool upload %s", filename)
+        return None, 0, "Could not read the uploaded file."
+
+    if written == 0:
+        Path(tmp_path).unlink(missing_ok=True)
+        return None, 0, _EMPTY_FILE
+
+    return tmp_path, written, None
+
+
+@router.post("/ingest/files", response_model=IngestFilesResponse)
+async def ingest_files_endpoint(
+    files: list[UploadFile] = File(...),
+    space: str = Form(default="default"),
+) -> IngestFilesResponse:
+    """Upload several files in one request.
+
+    Answers per file rather than as a single verdict. One malformed file in a
+    batch of thirty should not discard the other twenty-nine, and the caller
+    needs to know which one to fix — so the response lists every file with its
+    own outcome, and the request succeeds as long as it was well-formed.
+
+    A batch is bounded three ways: per file (the same cap a lone upload gets),
+    in aggregate, and by file count. Any one of them alone leaves an easy way
+    to spend all the disk and time available.
+    """
+    if len(files) > MAX_BATCH_FILES:
+        raise HTTPException(
+            status_code=status.HTTP_413_CONTENT_TOO_LARGE,
+            detail=f"Too many files. Maximum is {MAX_BATCH_FILES} per request.",
+        )
+
+    space_id = await _resolve_space_id(space)
+
+    results: list[IngestFileResult] = []
+    # Tempfile path -> the name the user uploaded. The pipeline reports errors
+    # keyed by the path it was given, and that path is a tempfile nobody asked
+    # about; echoing it back would leak server filesystem layout and mean
+    # nothing to the caller. This maps it back to their filename.
+    spooled: dict[str, str] = {}
+    budget = MAX_BATCH_BYTES
+
+    try:
+        for upload in files:
+            filename = upload.filename or ""
+
+            reason = _reject_bad_filename(filename)
+            if reason:
+                results.append(
+                    IngestFileResult(filename=filename or "(unnamed)", stored=False, error=reason)
+                )
+                continue
+
+            tmp_path, written, reason = await _spool_upload(upload, budget)
+            if reason:
+                results.append(IngestFileResult(filename=filename, stored=False, error=reason))
+                continue
+
+            assert tmp_path is not None  # nosec B101 — guaranteed when reason is None
+            budget -= written
+            spooled[tmp_path] = filename
+
+        chunks_created = 0
+        failures_by_name: dict[str, str] = {}
+
+        if spooled:
+            pipeline = IngestionPipeline(max_workers=1)
+            for tmp_path, filename in spooled.items():
+                # source_name is what the chunk records. Without it every
+                # chunk would point at a tempfile that is deleted before the
+                # response is sent — the same defect as a single upload, one
+                # per file instead of one per request.
+                pipeline.enqueue(tmp_path, space_id, source_name=filename)
+
+            try:
+                stats = await pipeline.run_all()
+            except Exception as exc:
+                logger.exception("Batch ingestion crashed for %d files", len(spooled))
+                raise HTTPException(
+                    status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                    detail="Ingestion failed. Check server logs.",
+                ) from exc
+
+            chunks_created = stats.chunks_created
+
+            for raw in stats.errors:
+                # Errors arrive as "<path>: <message>". Match the path back to
+                # the filename and keep only the message.
+                path, _, message = raw.partition(": ")
+                name = spooled.get(path)
+                if name is not None:
+                    failures_by_name[name] = message or "Could not be ingested."
+                else:
+                    logger.warning("Unmatched batch ingestion error: %s", raw)
+
+            for filename in spooled.values():
+                if filename in failures_by_name:
+                    results.append(
+                        IngestFileResult(
+                            filename=filename, stored=False, error=failures_by_name[filename]
+                        )
+                    )
+                else:
+                    results.append(IngestFileResult(filename=filename, stored=True))
+
+        succeeded = sum(1 for r in results if r.stored)
+        failed = len(results) - succeeded
+
+        return IngestFilesResponse(
+            files=results,
+            files_succeeded=succeeded,
+            files_failed=failed,
+            chunks_created=chunks_created,
+            message=(
+                f"Ingested {chunks_created} chunks from {succeeded} "
+                f"file{'' if succeeded == 1 else 's'}" + (f"; {failed} failed" if failed else "")
+            ),
+        )
+
+    finally:
+        for tmp_path in spooled:
             Path(tmp_path).unlink(missing_ok=True)

--- a/src/memory_vault/api/schemas.py
+++ b/src/memory_vault/api/schemas.py
@@ -157,6 +157,38 @@ class IngestResponse(BaseModel):
     message: str
 
 
+class IngestFileResult(BaseModel):
+    """What happened to one file in a batch upload.
+
+    No per-file chunk count: the pipeline accumulates chunks across the batch
+    and does not attribute them per job, so the only honest number is the
+    batch total on the response. Reporting a per-file zero would read as "this
+    file produced nothing" for files that produced plenty.
+    """
+
+    filename: str
+    stored: bool
+    error: str | None = Field(
+        default=None,
+        description="Why this file was not ingested. Absent when it succeeded.",
+    )
+
+
+class IngestFilesResponse(BaseModel):
+    """Per-file outcomes for a batch upload.
+
+    Reported per file rather than as a single verdict: a batch where one file
+    is malformed should still store the rest, and the caller needs to know
+    which one to fix rather than being told the upload failed.
+    """
+
+    files: list[IngestFileResult]
+    files_succeeded: int
+    files_failed: int
+    chunks_created: int
+    message: str
+
+
 # ---------------------------------------------------------------------------
 # Knowledge graph
 # ---------------------------------------------------------------------------

--- a/tests/test_bulk_ingest.py
+++ b/tests/test_bulk_ingest.py
@@ -1,0 +1,368 @@
+"""
+Uploading several files in one request.
+
+`/api/ingest/file` took one file per request, so importing a folder of notes
+meant one request per note. `/api/ingest/files` takes a batch.
+
+The interesting part is not the loop, it is what a batch makes possible that a
+single upload does not:
+
+**Partial success.** One malformed file in a batch of thirty must not discard
+the other twenty-nine, and the caller has to learn which one to fix. So the
+response reports per file and the request itself succeeds whenever it was
+well-formed.
+
+**Leaking the tempfile path.** The pipeline records failures as
+`"<path>: <message>"`, and that path is a tempfile the caller never named.
+Measured before writing this: a forced failure produced
+`/tmp/does-not-exist-at-all.md: [Errno 2] ...`. Returning those verbatim would
+publish server filesystem layout and tell the caller nothing — the same shape
+as #101, which put a tempfile path in a chunk's `source`. Errors are mapped
+back to the uploaded filename.
+
+**Three separate limits.** Per file, in aggregate, and by count. Any one alone
+leaves a way to spend all the disk available: fifty 24 MB files pass a per-file
+cap, and ten thousand tiny ones pass a byte cap.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from memory_vault.api.routers.ingest import (
+    MAX_BATCH_BYTES,
+    MAX_BATCH_FILES,
+    MAX_UPLOAD_BYTES,
+)
+
+
+def _file(name: str, body: bytes = b"# Notes\n\nAlice shipped the release.") -> tuple:
+    return ("files", (name, body, "text/markdown"))
+
+
+async def _post(client, auth_headers, files: list, space: str = "default"):
+    return await client.post(
+        "/api/ingest/files", files=files, data={"space": space}, headers=auth_headers
+    )
+
+
+class TestABatchIsIngested:
+    async def test_several_files_are_stored(self, client, auth_headers):
+        r = await _post(
+            client,
+            auth_headers,
+            [
+                _file("one.md", b"# One\n\nAlice shipped the release."),
+                _file("two.md", b"# Two\n\nBob reviewed the change."),
+            ],
+            space="bi1",
+        )
+
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["files_succeeded"] == 2
+        assert body["files_failed"] == 0
+        assert body["chunks_created"] >= 2
+
+    async def test_every_file_gets_its_own_result(self, client, auth_headers):
+        r = await _post(
+            client, auth_headers, [_file("a.md"), _file("b.md"), _file("c.md")], space="bi2"
+        )
+
+        results = r.json()["files"]
+        assert len(results) == 3
+        assert {x["filename"] for x in results} == {"a.md", "b.md", "c.md"}
+        assert all(x["stored"] for x in results)
+        assert all(x["error"] is None for x in results)
+
+    async def test_a_single_file_batch_works(self, client, auth_headers):
+        r = await _post(client, auth_headers, [_file("solo.md")], space="bi3")
+
+        assert r.status_code == 200, r.text
+        assert r.json()["files_succeeded"] == 1
+
+    async def test_the_space_is_created_on_first_write(self, client, auth_headers):
+        """Same as the single-file path — a batch should not need the space
+        to exist already."""
+        r = await _post(client, auth_headers, [_file("x.md")], space="brand-new-space")
+        assert r.status_code == 200, r.text
+
+        listing = await client.get("/api/spaces", headers=auth_headers)
+        assert "brand-new-space" in [s["name"] for s in listing.json()["spaces"]]
+
+    async def test_an_invalid_space_name_is_rejected(self, client, auth_headers):
+        r = await _post(client, auth_headers, [_file("x.md")], space="Not Valid")
+        assert r.status_code == 400, r.text
+
+
+class TestSourceNamesSurviveTheTempfile:
+    """
+    #101 in a new form. Each upload is spooled to a tempfile that is deleted
+    when the request ends; without the `source_name` override every chunk in
+    the batch would record a path that no longer exists.
+    """
+
+    async def test_chunks_record_the_uploaded_filename(self, client, auth_headers):
+        await _post(
+            client,
+            auth_headers,
+            [
+                _file("meeting-notes.md", b"# Meeting\n\nAlice shipped the release."),
+                _file("retro.md", b"# Retro\n\nBob reviewed the change."),
+            ],
+            space="bs1",
+        )
+
+        listing = await client.get("/api/chunks?space=bs1", headers=auth_headers)
+        sources = {c["source"] for c in listing.json()["chunks"]}
+
+        assert sources == {"meeting-notes.md", "retro.md"}, sources
+
+    async def test_no_chunk_records_a_temporary_path(self, client, auth_headers):
+        await _post(client, auth_headers, [_file("real-name.md")], space="bs2")
+
+        listing = await client.get("/api/chunks?space=bs2", headers=auth_headers)
+        for chunk in listing.json()["chunks"]:
+            source = chunk["source"] or ""
+            assert "/tmp/" not in source and "/var/folders" not in source, source
+            assert not source.startswith("/"), f"source should be a filename, got {source}"
+
+
+class TestPartialSuccess:
+    async def test_one_bad_file_does_not_discard_the_good_ones(self, client, auth_headers):
+        r = await _post(
+            client,
+            auth_headers,
+            [
+                _file("good.md", b"# Good\n\nAlice shipped the release."),
+                _file("empty.md", b""),
+                _file("also-good.md", b"# Also\n\nBob reviewed the change."),
+            ],
+            space="bp1",
+        )
+
+        assert r.status_code == 200, "a batch with one bad file is still a valid request"
+        body = r.json()
+        assert body["files_succeeded"] == 2
+        assert body["files_failed"] == 1
+
+        listing = await client.get("/api/chunks?space=bp1", headers=auth_headers)
+        assert listing.json()["total"] >= 2, "the good files must have been stored"
+
+    async def test_the_failing_file_is_named(self, client, auth_headers):
+        """ "Something failed" would leave the caller re-uploading everything."""
+        r = await _post(
+            client, auth_headers, [_file("fine.md"), _file("broken.md", b"")], space="bp2"
+        )
+
+        by_name = {x["filename"]: x for x in r.json()["files"]}
+        assert by_name["broken.md"]["stored"] is False
+        assert by_name["broken.md"]["error"]
+        assert by_name["fine.md"]["stored"] is True
+
+    async def test_an_empty_file_is_reported_not_silently_skipped(self, client, auth_headers):
+        r = await _post(client, auth_headers, [_file("nothing.md", b"")], space="bp3")
+
+        body = r.json()
+        assert body["files_failed"] == 1
+        assert "empty" in body["files"][0]["error"].lower()
+
+    async def test_the_message_mentions_failures(self, client, auth_headers):
+        r = await _post(client, auth_headers, [_file("ok.md"), _file("bad.md", b"")], space="bp4")
+        assert "failed" in r.json()["message"]
+
+
+class TestTempPathsNeverReachTheCaller:
+    """
+    The leak this endpoint has to avoid, and the reason failures are not
+    passed through verbatim.
+    """
+
+    async def test_no_response_field_contains_a_temporary_path(self, client, auth_headers):
+        import json
+
+        r = await _post(
+            client,
+            auth_headers,
+            [_file("good.md"), _file("empty.md", b""), _file("../evil.md", b"x")],
+            space="bt1",
+        )
+
+        body = json.dumps(r.json())
+        assert "/tmp/" not in body, body
+        assert "/var/folders" not in body, body
+        assert "NamedTemporary" not in body
+
+    async def test_errors_are_about_the_uploaded_name(self, client, auth_headers):
+        r = await _post(client, auth_headers, [_file("mine.md", b"")], space="bt2")
+
+        result = r.json()["files"][0]
+        assert result["filename"] == "mine.md"
+        assert result["error"] is not None
+        assert ".md:" not in result["error"], (
+            f"the raw '<path>: <message>' form leaked through: {result['error']}"
+        )
+
+    # The cases above are all rejected before the pipeline runs, so they never
+    # populate `stats.errors` — the very place the tempfile path comes from.
+    # These two reach the pipeline and fail inside it, which is the only path
+    # that exercises the mapping. Found by mutation: passing the raw error
+    # through left every test above still green.
+    @pytest.mark.parametrize(
+        ("name", "body"),
+        [
+            # NUL bytes survive the adapter and fail at insert.
+            ("binary.md", b"Alice shipped\x00the release."),
+            # Shaped like a Claude export, wrong inside.
+            ("export.json", b'{"chat_messages": "not-a-list"}'),
+        ],
+    )
+    async def test_a_pipeline_failure_does_not_leak_its_temp_path(
+        self, client, auth_headers, name, body
+    ):
+        import json
+
+        r = await _post(client, auth_headers, [_file(name, body)], space="bt3")
+
+        assert r.status_code == 200, r.text
+        result = r.json()["files"][0]
+        assert result["stored"] is False, "precondition: this file must fail inside the pipeline"
+        assert result["filename"] == name
+
+        error = result["error"] or ""
+        assert "/tmp/" not in error, f"tempfile path leaked into the error: {error}"
+        assert "/var/folders" not in error, error
+        assert not error.startswith("/"), error
+        assert "/tmp/" not in json.dumps(r.json())
+
+    async def test_a_pipeline_failure_still_reports_something_useful(self, client, auth_headers):
+        """
+        Stripping the path must not strip the reason — a bare "failed" would
+        leave the caller with nothing to act on.
+        """
+        r = await _post(client, auth_headers, [_file("binary.md", b"Alice\x00Bob")], space="bt4")
+
+        error = r.json()["files"][0]["error"]
+        assert error, "the failure needs a message"
+        assert len(error) > 10, f"message is too thin to act on: {error!r}"
+
+
+class TestBadFilenames:
+    @pytest.mark.parametrize(
+        "name", ["../escape.md", "../../etc/passwd", "dir/nested.md", "back\\slash.md", ".hidden"]
+    )
+    async def test_traversal_and_separators_are_refused(self, client, auth_headers, name):
+        """
+        The path on disk is a tempfile, so there is no real escape — but the
+        name is echoed back and stored as the chunk's source.
+        """
+        r = await _post(client, auth_headers, [_file(name, b"content")], space="bf1")
+
+        assert r.status_code == 200
+        assert r.json()["files_failed"] == 1
+        assert r.json()["files_succeeded"] == 0
+
+    async def test_a_bad_name_does_not_stop_the_rest(self, client, auth_headers):
+        r = await _post(
+            client, auth_headers, [_file("../evil.md", b"x"), _file("fine.md")], space="bf2"
+        )
+
+        body = r.json()
+        assert body["files_succeeded"] == 1
+        assert body["files_failed"] == 1
+
+
+class TestLimits:
+    async def test_the_three_caps_are_distinct(self):
+        """
+        Each closes a hole the others leave open: many small files pass a byte
+        cap, and a few large ones pass a count cap.
+        """
+        assert MAX_UPLOAD_BYTES == 25 * 1024 * 1024
+        assert MAX_BATCH_BYTES == 100 * 1024 * 1024
+        assert MAX_BATCH_FILES == 100
+        assert MAX_BATCH_BYTES > MAX_UPLOAD_BYTES
+
+    async def test_too_many_files_is_refused_outright(self, client, auth_headers):
+        """A count this far over the line is rejected before anything is read."""
+        files = [_file(f"f{i}.md", b"x") for i in range(MAX_BATCH_FILES + 1)]
+
+        r = await _post(client, auth_headers, files, space="bl1")
+
+        assert r.status_code == 413, r.text
+
+    async def test_a_file_over_the_per_file_cap_is_refused(self, client, auth_headers):
+        big = b"x" * (MAX_UPLOAD_BYTES + 1024)
+
+        r = await _post(client, auth_headers, [_file("huge.md", big)], space="bl2")
+
+        assert r.status_code == 200, "an oversized file is a per-file failure, not a bad request"
+        result = r.json()["files"][0]
+        assert result["stored"] is False
+        assert "limit" in result["error"].lower()
+
+    async def test_one_oversized_file_does_not_stop_the_others(self, client, auth_headers):
+        big = b"x" * (MAX_UPLOAD_BYTES + 1024)
+
+        r = await _post(
+            client,
+            auth_headers,
+            [_file("fine.md"), _file("huge.md", big), _file("also-fine.md")],
+            space="bl3",
+        )
+
+        body = r.json()
+        assert body["files_succeeded"] == 2
+        assert body["files_failed"] == 1
+
+    async def test_the_batch_stays_under_its_aggregate_cap(self, client, auth_headers):
+        """
+        Each file is under the per-file cap; together they pass the batch cap.
+        This is the case a per-file limit alone does not catch.
+        """
+        one_file = MAX_UPLOAD_BYTES - 1024
+        count = (MAX_BATCH_BYTES // one_file) + 2
+        files = [_file(f"big{i}.md", b"x" * one_file) for i in range(count)]
+
+        r = await _post(client, auth_headers, files, space="bl4")
+
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["files_failed"] > 0, "the aggregate cap should have stopped the tail"
+        assert any("total limit" in (x["error"] or "").lower() for x in body["files"]), [
+            x["error"] for x in body["files"]
+        ]
+
+
+class TestAuthentication:
+    async def test_a_batch_upload_requires_a_token(self, client):
+        r = await client.post(
+            "/api/ingest/files",
+            files=[_file("x.md")],
+            data={"space": "ba1"},
+        )
+        assert r.status_code in (401, 403), r.text
+
+
+class TestTheSingleFileEndpointIsUnchanged:
+    """The batch endpoint is additive; the existing one is what callers use."""
+
+    async def test_single_upload_still_works(self, client, auth_headers):
+        r = await client.post(
+            "/api/ingest/file",
+            files={"file": ("solo.md", b"# Solo\n\nAlice shipped the release.", "text/markdown")},
+            data={"space": "bu1"},
+            headers=auth_headers,
+        )
+
+        assert r.status_code == 200, r.text
+        assert r.json()["chunks_created"] >= 1
+
+    async def test_single_upload_still_rejects_a_bad_filename(self, client, auth_headers):
+        r = await client.post(
+            "/api/ingest/file",
+            files={"file": ("../evil.md", b"x", "text/markdown")},
+            data={"space": "bu2"},
+            headers=auth_headers,
+        )
+        assert r.status_code == 400, r.text

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -80,6 +80,23 @@ export interface IngestResponse {
   message: string
 }
 
+/** One file's outcome in a batch upload. */
+export interface IngestFileResult {
+  filename: string
+  stored: boolean
+  /** Why it was not ingested. Null when it succeeded. */
+  error: string | null
+}
+
+export interface IngestFilesResponse {
+  files: IngestFileResult[]
+  files_succeeded: number
+  files_failed: number
+  /** Batch total — the pipeline does not attribute chunks per file. */
+  chunks_created: number
+  message: string
+}
+
 export interface ListChunksParams {
   space?: string
   /** Only chunks mentioning this knowledge-graph entity. */
@@ -282,6 +299,25 @@ export const api = {
     form.append('file', file)
     form.append('space', space)
     return request<IngestResponse>('/api/ingest/file', {
+      method: 'POST',
+      body: form,
+    })
+  },
+
+  /**
+   * Upload several files in one request, answering per file.
+   *
+   * The Ingest page deliberately still uploads one at a time: it shows each
+   * file flipping to done with its own chunk count, and a single batch call
+   * would leave that list frozen until everything finished. This is for
+   * callers importing a folder programmatically, where one round trip beats
+   * fifty.
+   */
+  ingestFiles: (files: File[], space: string = 'default') => {
+    const form = new FormData()
+    for (const file of files) form.append('files', file)
+    form.append('space', space)
+    return request<IngestFilesResponse>('/api/ingest/files', {
       method: 'POST',
       body: form,
     })


### PR DESCRIPTION
## What

`POST /api/ingest/files` uploads several files in one request and answers per file. Importing a folder of notes previously meant one request per note.

## Partial success

One malformed file in a batch of thirty must not discard the other twenty-nine, and the caller has to learn which one to fix. So the request itself succeeds whenever it was well-formed, and every file carries its own outcome:

```json
{
  "files": [
    {"filename": "notes.md",  "stored": true,  "error": null},
    {"filename": "binary.md", "stored": false, "error": "PostgreSQL text fields cannot contain NUL (0x00) bytes"}
  ],
  "files_succeeded": 1, "files_failed": 1, "chunks_created": 1
}
```

## The leak this had to avoid

The pipeline records failures as `"<path>: <message>"`, and that path is a tempfile the caller never named. Measured before writing any tests — a forced failure produced:

```
/tmp/tmpyb3d8i0f.md: PostgreSQL text fields cannot contain NUL (0x00) bytes
```

Returning those verbatim would publish server filesystem layout and tell the caller nothing. It is the same shape as the bug that once recorded a temporary path as a chunk's `source`. Errors are mapped back to the uploaded filename and only the message is kept.

## Limits

Three, because any one alone leaves a gap: **per file** (25 MB, the same cap a lone upload gets — arriving with company should not make a file more permissive), **in aggregate** (100 MB), and **by count** (100 files). Fifty files of 24 MB pass a per-file cap; ten thousand tiny ones pass a byte cap.

## Notes

Each chunk records the uploaded name rather than the tempfile it was read from, so the source survives the request that created it.

No per-file chunk count: the pipeline accumulates chunks across the batch and does not attribute them per job. A per-file zero would read as "this file produced nothing" for files that produced plenty, so the response carries only the honest batch total.

**The dashboard still uploads one file at a time, deliberately.** It shows each row flipping to done with its own chunk count, and a single batch call would leave that list frozen until everything finished — worse for a fifty-file import, not better. The batch endpoint is for callers importing a folder programmatically; `api.ingestFiles()` is there for them.

Also updates two uses of the deprecated `HTTP_413_REQUEST_ENTITY_TOO_LARGE` constant that Starlette now warns about.

## Tests

30 new (607 total, all passing):

- a batch is stored; each file gets its own result; the space is created on first write
- chunks record the uploaded filename, and no chunk records a temporary path
- one bad file does not discard the good ones, and the failing file is named
- pipeline failures do not leak their temp path, but still report something actionable
- traversal and separator filenames are refused without stopping the rest
- all three caps hold, including an oversized file among good ones
- the single-file endpoint is unchanged

Mutation-tested four ways: dropping `source_name` (2 failures), removing the aggregate cap (1), removing the file-count cap (1 — 101 files sailed through), and passing the raw pipeline error through.

**That last one initially survived**, which was a real gap: every failure the suite produced was caught *before* the pipeline ran, so `stats.errors` — the only place the tempfile path comes from — was never exercised. Added two cases that fail *inside* the pipeline (NUL bytes, a malformed Claude export), and the mutation now fails both. Without that the leak could have shipped.

Verified against a running server: 2 stored, 2 failed with usable reasons, no path in the response, sources recorded as `['notes.md', 'retro.md']`.
