### PR TITLE
Use an event loop psycopg can talk to on Windows

### DIFF
--- a/src/memory_vault/__init__.py
+++ b/src/memory_vault/__init__.py
@@ -1,10 +1,63 @@
 """Memory Vault package."""
 
+import asyncio
+import sys
 from importlib.metadata import PackageNotFoundError, version
 
 try:
     __version__ = version("memory-vault")
 except PackageNotFoundError:
     __version__ = "unknown"
+
+
+def _use_selector_event_loop_on_windows() -> bool:
+    """Make asyncio use a loop psycopg can actually talk to, on Windows.
+
+    Windows defaults to ``ProactorEventLoop``, and psycopg refuses to run on
+    it: ``AsyncConnection.connect`` raises ``InterfaceError`` before any
+    network I/O happens. The pool reads that as a failed connection and
+    retries, and every retry raises instantly — so a start-up that should be
+    immediate becomes a burst of identical warnings and a several-second delay
+    before anything works. Reproduced on Windows 11 with the versions this
+    package pins: three warnings inside a five-second window, then
+    ``PoolTimeout``.
+
+    Forcing the selector loop costs nothing here. The one thing it cannot do
+    is asyncio subprocesses, and this package never starts one: ``diagnose``
+    uses the synchronous ``subprocess.run``, and the MCP server reads stdio
+    directly rather than spawning anything. Both were confirmed on Windows
+    rather than only by reading the source.
+
+    Set at import so every entry point inherits it — CLI, API and MCP server
+    alike — because the loop has to be chosen before anyone calls
+    ``asyncio.run``. It only ever touches Windows: on every other platform
+    this returns immediately, and ``WindowsSelectorEventLoopPolicy`` does not
+    even exist there.
+
+    Returns whether the policy was changed, which is what makes this testable
+    on a non-Windows machine.
+    """
+    if sys.platform != "win32":  # pragma: no cover - platform-specific
+        return False
+
+    policy_cls = getattr(asyncio, "WindowsSelectorEventLoopPolicy", None)
+    if policy_cls is None:  # pragma: no cover - defensive, Windows always has it
+        return False
+
+    # Leave a deliberate choice alone. An embedding application that has
+    # already selected a policy knows something about its own needs that this
+    # import does not, and silently overriding it would be worse than the
+    # warnings this avoids.
+    current = asyncio.get_event_loop_policy()
+    if isinstance(current, policy_cls):
+        return False
+    if type(current) is not asyncio.DefaultEventLoopPolicy:
+        return False
+
+    asyncio.set_event_loop_policy(policy_cls())
+    return True
+
+
+_use_selector_event_loop_on_windows()
 
 __all__ = ["__version__"]

--- a/tests/test_windows_event_loop.py
+++ b/tests/test_windows_event_loop.py
@@ -36,10 +36,17 @@ import asyncio
 import subprocess
 import sys
 import textwrap
+from pathlib import Path
 
 import pytest
 
+from memory_vault import __file__ as _package_file
 from memory_vault import _use_selector_event_loop_on_windows
+
+# Where the installed package lives. Derived once, in the same `from` style as
+# the import above: mixing `from x import y` with `import x` in one file is
+# something the code-quality bot flags and ruff does not catch.
+PACKAGE_DIR = Path(_package_file).parent
 
 
 class TestOnThisPlatform:
@@ -95,6 +102,14 @@ class TestItIsWiredIntoImport:
         """
         code = textwrap.dedent("""
             import asyncio, sys
+
+            # Warm the stdlib BEFORE faking the platform. Modules imported
+            # after the lie take their Windows branches: on 3.13 `shutil`
+            # does `import _winapi` at module level, which does not exist on
+            # Linux, so importing anything afterwards dies with
+            # ModuleNotFoundError. 3.11 imports it lazily and survived, which
+            # is why this only failed on one of the two CI versions.
+            import importlib.metadata, shutil, zipfile  # noqa: F401
 
             class FakeSelectorPolicy(asyncio.DefaultEventLoopPolicy):
                 pass
@@ -203,11 +218,8 @@ class TestTheReasonTheFixIsSafe:
     """
 
     def test_no_module_uses_asyncio_subprocesses(self):
-        from pathlib import Path
-
-        src = Path(__import__("memory_vault").__file__).parent
         offenders = []
-        for path in src.rglob("*.py"):
+        for path in PACKAGE_DIR.rglob("*.py"):
             text = path.read_text(encoding="utf-8")
             if "create_subprocess_exec" in text or "create_subprocess_shell" in text:
                 offenders.append(path.name)
@@ -220,11 +232,7 @@ class TestTheReasonTheFixIsSafe:
     def test_diagnose_uses_the_synchronous_subprocess_api(self):
         """`subprocess.run` is unaffected by the event loop — verified on
         Windows, where it returned 42 under the selector policy."""
-        from pathlib import Path
-
-        import memory_vault
-
-        diagnose = Path(memory_vault.__file__).parent / "diagnose.py"
+        diagnose = PACKAGE_DIR / "diagnose.py"
         if not diagnose.exists():  # pragma: no cover - defensive
             pytest.skip("diagnose.py not present")
 

--- a/tests/test_windows_event_loop.py
+++ b/tests/test_windows_event_loop.py
@@ -1,0 +1,233 @@
+"""
+Choosing an event loop psycopg can use, on Windows.
+
+Windows defaults to `ProactorEventLoop`, and psycopg refuses to run on it —
+`AsyncConnection.connect` raises `InterfaceError` before attempting any network
+I/O. The pool reads that as a failed connection and retries; every retry raises
+instantly. Start-up becomes a burst of identical warnings and a multi-second
+delay before anything works.
+
+Reproduced on Windows 11 with the versions this package pins (psycopg 3.3.5,
+psycopg-pool 3.3.1):
+
+    loop: ProactorEventLoop
+    WARNING error connecting in 'pool-1': Psycopg cannot use the
+      'ProactorEventLoop' to run in async mode. ...        (x3)
+    OUTCOME: PoolTimeout pool initialization incomplete after 5 sec
+
+and with the selector policy forced, on the same machine:
+
+    loop: _WindowsSelectorEventLoop
+    OUTCOME: PoolTimeout pool initialization incomplete after 5 sec
+
+Zero guard errors. The remaining timeout is the probe pointing at a dead port
+on purpose — what changed is *why* it failed.
+
+These tests run on Linux in CI, where `WindowsSelectorEventLoopPolicy` does not
+exist and the function is a no-op. So they assert on the decision the function
+makes rather than on a policy it cannot set here: that it declines on this
+platform, that it is wired into import, and that it leaves a caller's own
+choice alone. The Windows behaviour itself was verified on Windows.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+from memory_vault import _use_selector_event_loop_on_windows
+
+
+class TestOnThisPlatform:
+    @pytest.mark.skipif(sys.platform == "win32", reason="the non-Windows path")
+    def test_it_declines_off_windows(self):
+        assert _use_selector_event_loop_on_windows() is False
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="the non-Windows path")
+    def test_the_policy_is_left_alone_off_windows(self):
+        """
+        Importing a library should not rearrange asyncio for everyone else.
+        On Linux and macOS the default loop is already one psycopg is happy
+        with, so there is nothing to fix and nothing to touch.
+        """
+        before = type(asyncio.get_event_loop_policy())
+
+        _use_selector_event_loop_on_windows()
+
+        assert type(asyncio.get_event_loop_policy()) is before
+
+    @pytest.mark.skipif(sys.platform != "win32", reason="the Windows path")
+    def test_it_selects_a_psycopg_compatible_loop_on_windows(self):  # pragma: no cover
+        """Runs only on Windows; CI is Linux, so this is for a local run there."""
+        policy = asyncio.get_event_loop_policy()
+        assert isinstance(policy, asyncio.WindowsSelectorEventLoopPolicy)
+
+        loop = policy.new_event_loop()
+        try:
+            assert "Proactor" not in type(loop).__name__
+        finally:
+            loop.close()
+
+
+class TestItIsWiredIntoImport:
+    """
+    The loop has to be chosen before anything calls `asyncio.run`, so the call
+    belongs at import rather than in one entry point. A fix that only ran under
+    `memory-vault api` would leave the MCP server and the CLI broken.
+    """
+
+    def test_importing_the_package_applies_the_policy(self):
+        """
+        Observes the effect of importing, rather than reading the source for a
+        call. An earlier version of this test grepped the file for
+        `_use_selector_event_loop_on_windows()` and passed happily with the
+        call deleted — the function's own `def` line contains that string.
+        Found by mutation.
+
+        The platform is faked inside a subprocess so this exercises the real
+        Windows branch from Linux: `sys.platform` is patched and a stand-in
+        policy class installed before the package is imported, then the policy
+        is read back afterwards.
+        """
+        code = textwrap.dedent("""
+            import asyncio, sys
+
+            class FakeSelectorPolicy(asyncio.DefaultEventLoopPolicy):
+                pass
+
+            sys.platform = "win32"
+            asyncio.WindowsSelectorEventLoopPolicy = FakeSelectorPolicy
+
+            import memory_vault  # noqa: F401  - the import is the thing under test
+
+            applied = isinstance(asyncio.get_event_loop_policy(), FakeSelectorPolicy)
+            print("POLICY_APPLIED", applied)
+        """)
+
+        result = subprocess.run(  # noqa: S603
+            [sys.executable, "-c", code], capture_output=True, text=True, timeout=120
+        )
+
+        assert result.returncode == 0, result.stderr
+        assert "POLICY_APPLIED True" in result.stdout, (
+            "importing the package must apply the policy on Windows; got: "
+            f"{result.stdout!r} {result.stderr[-400:]!r}"
+        )
+
+    def test_it_is_applied_before_the_entry_points_are_defined(self):
+        """
+        Importing any module in the package is enough — the CLI, the API and
+        the MCP server all import `memory_vault` first.
+        """
+        code = textwrap.dedent("""
+            import memory_vault.cli  # noqa: F401
+            import sys
+            print("imported-without-error", sys.platform)
+        """)
+
+        result = subprocess.run(  # noqa: S603
+            [sys.executable, "-c", code], capture_output=True, text=True, timeout=120
+        )
+
+        assert result.returncode == 0, result.stderr
+        assert "imported-without-error" in result.stdout
+
+
+class TestItDoesNotOverrideADeliberateChoice:
+    """
+    An application embedding this package may have chosen a policy for its own
+    reasons — uvloop, or a custom one. Silently replacing it would be a worse
+    failure than the warnings this avoids, and far harder to debug.
+    """
+
+    def test_a_custom_policy_is_left_in_place(self, monkeypatch):
+        """
+        The two classes must be *different*. An earlier version used one class
+        for both the stand-in selector policy and the caller's policy, so the
+        `isinstance(current, policy_cls)` check returned first and the guard
+        under test never ran — the test passed with that guard deleted. Found
+        by mutation.
+        """
+
+        class SelectorStandIn(asyncio.DefaultEventLoopPolicy):
+            pass
+
+        class SomebodyElsesPolicy(asyncio.DefaultEventLoopPolicy):
+            """Not the default type, and not the selector one either."""
+
+        monkeypatch.setattr(sys, "platform", "win32")
+        monkeypatch.setattr(
+            asyncio, "WindowsSelectorEventLoopPolicy", SelectorStandIn, raising=False
+        )
+
+        theirs = SomebodyElsesPolicy()
+        monkeypatch.setattr(asyncio, "get_event_loop_policy", lambda: theirs)
+
+        applied: list[object] = []
+        monkeypatch.setattr(asyncio, "set_event_loop_policy", applied.append)
+
+        changed = _use_selector_event_loop_on_windows()
+
+        assert changed is False, "a caller's own policy must not be replaced"
+        assert applied == [], f"it overwrote a deliberate choice: {applied}"
+
+    def test_it_does_not_reapply_when_already_selector(self, monkeypatch):
+        class FakeSelectorPolicy(asyncio.DefaultEventLoopPolicy):
+            pass
+
+        applied: list[object] = []
+
+        monkeypatch.setattr(sys, "platform", "win32")
+        monkeypatch.setattr(
+            asyncio, "WindowsSelectorEventLoopPolicy", FakeSelectorPolicy, raising=False
+        )
+        monkeypatch.setattr(asyncio, "get_event_loop_policy", FakeSelectorPolicy)
+        monkeypatch.setattr(asyncio, "set_event_loop_policy", applied.append)
+
+        changed = _use_selector_event_loop_on_windows()
+
+        assert changed is False
+        assert applied == [], "setting it twice is pointless work at every import"
+
+
+class TestTheReasonTheFixIsSafe:
+    """
+    The selector loop cannot run asyncio subprocesses. That is fine only
+    because this package never starts one — checked here so a future change
+    that adds `create_subprocess_exec` has to notice this trade-off rather
+    than discover it on a user's Windows machine.
+    """
+
+    def test_no_module_uses_asyncio_subprocesses(self):
+        from pathlib import Path
+
+        src = Path(__import__("memory_vault").__file__).parent
+        offenders = []
+        for path in src.rglob("*.py"):
+            text = path.read_text(encoding="utf-8")
+            if "create_subprocess_exec" in text or "create_subprocess_shell" in text:
+                offenders.append(path.name)
+
+        assert not offenders, (
+            f"asyncio subprocesses do not work under the selector loop this "
+            f"package selects on Windows: {offenders}"
+        )
+
+    def test_diagnose_uses_the_synchronous_subprocess_api(self):
+        """`subprocess.run` is unaffected by the event loop — verified on
+        Windows, where it returned 42 under the selector policy."""
+        from pathlib import Path
+
+        import memory_vault
+
+        diagnose = Path(memory_vault.__file__).parent / "diagnose.py"
+        if not diagnose.exists():  # pragma: no cover - defensive
+            pytest.skip("diagnose.py not present")
+
+        text = diagnose.read_text(encoding="utf-8")
+        if "subprocess" in text:
+            assert "create_subprocess" not in text


### PR DESCRIPTION
Closes #77.

## What

Memory Vault now selects an event loop psycopg can actually use on Windows.

## The bug

Windows defaults to `ProactorEventLoop`. psycopg refuses to run on it — `AsyncConnection.connect` raises `InterfaceError` **before attempting any network I/O** (`psycopg/connection_async.py`, the `sys.platform == "win32"` guard). The pool reads that as a failed connection and retries; every retry raises instantly. Start-up became a burst of identical warnings and a multi-second delay before anything worked.

Reproduced on Windows 11 with the exact versions this package pins — psycopg 3.3.5, psycopg-pool 3.3.1 — using a bare pool pointed at a closed port:

```
DEBUG Using proactor: IocpProactor
loop: ProactorEventLoop
WARNING error connecting in 'pool-1': Psycopg cannot use the 'ProactorEventLoop' to run in async mode. ...
WARNING error connecting in 'pool-1': ... (x3)
OUTCOME: PoolTimeout pool initialization incomplete after 5 sec
```

The dead port matters: the guard fires before the socket is touched, so this is unambiguously about the event loop rather than connectivity.

## The fix, measured

Same probe, same machine, with the selector policy applied:

```
DEBUG Using selector: SelectSelector
loop: _WindowsSelectorEventLoop
OUTCOME: PoolTimeout pool initialization incomplete after 5 sec
```

| | before | after |
|---|---|---|
| loop | `ProactorEventLoop` | `_WindowsSelectorEventLoop` |
| guard errors | **3** | **0** |

The remaining `PoolTimeout` is expected — the probe points at a closed port on purpose. What changed is *why* it failed.

## Why at import

The loop has to be chosen before anything calls `asyncio.run`, so a fix inside one entry point would leave the others broken — the CLI, the API and the MCP server all need it.

It declines when a policy has already been chosen deliberately. An application embedding this package that selected uvloop knows something this import does not, and silently overriding it would be a worse failure than the warnings being avoided. Verified on Windows that the *default* policy is not mistaken for a deliberate one: `WindowsProactorEventLoopPolicy` reports `is Default: True`, so the check does not skip the case it exists for.

## Why it is safe

The selector loop cannot run asyncio subprocesses. That is fine only because this package never starts one — `diagnose` uses the synchronous `subprocess.run`, and the MCP server reads stdio rather than spawning. Confirmed on Windows rather than only by reading the source:

```
sync subprocess: 42 (expect 42)
async under selector: ok
async subprocess NOT supported (expected on Selector)
```

A test now fails if anything later adds `create_subprocess_exec`, so the trade-off has to be noticed rather than discovered on a user's machine.

Non-Windows platforms are untouched: the function returns immediately, and `WindowsSelectorEventLoopPolicy` does not exist there.

## Tests

9 new (615 passing, 1 skipped — the Windows-only assertion, correctly skipped on Linux CI).

Mutation-tested three ways, and **two of the three exposed tests that passed for the wrong reason**:

- Deleting the call at import: originally survived. The test grepped the source for `_use_selector_event_loop_on_windows()`, which still matched the function's own `def` line. Rewritten to fake the platform in a subprocess and observe the policy actually change — it now fails when the call is removed.
- Deleting the "respect a deliberate choice" guard: originally survived, because the test used one class for both the stand-in policy and the caller's, so an earlier `isinstance` check returned first and the guard never ran. Rewritten with two distinct classes.
- Removing the `sys.platform` check survives, and that is correct: on Linux `WindowsSelectorEventLoopPolicy` does not exist, so the next check returns anyway. It is redundant defence, not the load-bearing line.
