### PR TITLE
Release v1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,67 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.0] — 2026-09-05
+
+Eight additions, most of them about doing something with a graph you have
+already built: reading the memories behind a node, filtering by more than one
+type at a time, and merging the entities that extraction split apart. Plus a
+Windows fix that had been waiting on a reproduction.
+
+Nothing here requires action on upgrade. Every new parameter is optional, and
+every existing call behaves as it did.
+
+### Added
+
+- **Merge entities the extractor kept apart.** Extraction is literal and
+  per-occurrence, so one person arrives as "Alice", "Alice Smith" and
+  "A. Smith". `POST /api/graph/entities/merge` folds one into another in a
+  single transaction. Deciding that two entities are the same is a judgement
+  call, so it is offered rather than guessed at. Merging across spaces is
+  refused: entities are per-space by design, and a cross-space merge would move
+  data between spaces without saying so.
+- **Read the memories behind a graph node.** `GET /api/chunks?entity_id=…`
+  returns the chunks that mention an entity, and the graph's node panel links
+  into Browse with that filter applied. The node used to be a dead end — you
+  could see that something mattered and how often it came up, but not read what
+  it came from.
+- **Filter the graph by several types at once.** `?type=Person,Tool` on the
+  entity, relationship and visualization endpoints. Selecting two types meant
+  two requests and no way to see both together. A single value still behaves
+  exactly as before.
+- **Delete a space.** `DELETE /api/spaces/{name}` removes one that holds
+  nothing, with a two-step delete on the dashboard. Spaces could be created but
+  never removed, so a typo was permanent. A space with contents is refused
+  rather than emptied — and "empty" means no memories *and* no graph entities,
+  since deleting a space cascades into its entities.
+- **Upload several files in one request.** `POST /api/ingest/files` answers per
+  file: one malformed file in a batch of thirty does not discard the other
+  twenty-nine, and the response says which one to fix. Bounded per file, in
+  aggregate, and by count.
+- **Tune search breadth per query.** `ef_search` on `/api/search` and the MCP
+  `recall` tool widens the HNSW search for one query without changing the
+  server default for everyone. Bounded 1–1000.
+- **The vector index is warmed at start-up.** `memory-vault warm-index` runs
+  after migrations, so the first real search is not the one that pays to read
+  the index off disk. Warming never blocks start-up: a container that refuses to
+  start because an optimisation failed is worse than a slow first query.
+
+### Fixed
+
+- **Memory Vault now starts cleanly on Windows.** Windows defaults to an event
+  loop psycopg refuses to use, so every connection attempt failed instantly and
+  the pool retried — a burst of identical warnings and a multi-second delay
+  before anything worked. A compatible loop is now selected at import.
+  Reproduced on Windows 11 beforehand and measured after: three warnings and a
+  pool timeout became zero warnings. Other platforms are untouched. ([#77])
+
+### Contributors
+
+- Rivestack suggested both the per-query `ef_search` knob and warming the vector
+  index at start-up.
+
+[#77]: https://github.com/MihaiBuilds/memory-vault/issues/77
+
 ## [1.4.0] — 2026-08-23
 
 Ten bug fixes and one new capability. Most of these are the kind that only

--- a/README.md
+++ b/README.md
@@ -609,6 +609,7 @@ The [GitHub contributor list](https://github.com/MihaiBuilds/memory-vault/graphs
 
 - **Leonard Janke (lcjanke2020), working with GPT-5.6-Sol through OpenAI Codex** ([@lcj-codex-coder](https://github.com/lcj-codex-coder)) — 20+ issues reported across the v1.0.7–v1.0.10 window, spanning version-drift, MCP correctness, timezone handling, embedding-dimension validation, and knowledge-graph soft-delete semantics. Peer-tier diagnostics; every report came with a disposable-database reproduction.
 - **[@git-pharos](https://github.com/git-pharos)** — diagnostic bundle in [#74](https://github.com/MihaiBuilds/memory-vault/issues/74) that exposed three underlying issues fixed in v1.0.7.
+- **Rivestack** — the per-query `ef_search` knob and warming the vector index at start-up, both shipped in v1.5.0. Operational pgvector experience: the kind of default that is fine in a demo and wrong at scale.
 
 Security reports and correctness findings are always credited by handle, plus any format the reporter specified — including tooling attribution where requested.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       retries: 10
 
   app:
-    image: ghcr.io/mihaibuilds/memory-vault:1.4.0
+    image: ghcr.io/mihaibuilds/memory-vault:1.5.0
     depends_on:
       db:
         condition: service_healthy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "memory-vault"
-version = "1.4.0"
+version = "1.5.0"
 description = "Local-first AI memory system with hybrid search — PostgreSQL + pgvector"
 readme = "README.md"
 license = "MIT"

--- a/server.json
+++ b/server.json
@@ -8,11 +8,11 @@
     "url": "https://github.com/MihaiBuilds/memory-vault",
     "source": "github"
   },
-  "version": "1.4.0",
+  "version": "1.5.0",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/mihaibuilds/memory-vault-mcp:1.4.0",
+      "identifier": "ghcr.io/mihaibuilds/memory-vault-mcp:1.5.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## What

Version bump and CHANGELOG for v1.5.0.

- `pyproject.toml` — 1.4.0 → 1.5.0
- `docker-compose.yml` — image tag
- `server.json` — both the `version` field **and** the MCP OCI identifier
- `CHANGELOG.md` — the release entry
- `README.md` — Rivestack added to Acknowledgments

## What is in the release

Eight additions, most of them about doing something with a graph you have already built, plus a Windows fix that had been waiting on a reproduction:

| | |
|---|---|
| Merge entities | `POST /api/graph/entities/merge` (#211) |
| Read memories behind a node | `?entity_id=` on `/api/chunks` (#208) |
| Multi-type graph filter | `?type=Person,Tool` (#206) |
| Delete a space | `DELETE /api/spaces/{name}` (#207) |
| Bulk upload | `POST /api/ingest/files` (#209) |
| Per-query search breadth | `ef_search` (#204) |
| Index warm-up at start | `memory-vault warm-index` (#205) |
| Windows start-up | closes #77 (#210) |

Nothing requires action on upgrade: every new parameter is optional and every existing call behaves as it did.

## Verification

636 tests passing, 1 skipped (a Windows-only assertion, correctly skipped on Linux). Up from 43 test files at v1.4.0 to 51.

`pytest tests/test_version_reporting.py` passes, which is what confirms the four version sites agree — that test exists because one of them was missed in an earlier release.

Note `pyproject.toml` also contains `pytest-asyncio>=1.4.0`, a dependency pin that coincidentally matched the old version string. Each site was edited explicitly rather than by find-and-replace, and that line is deliberately unchanged.
